### PR TITLE
[feat] 회원가입 기능 구현

### DIFF
--- a/EnF/build.gradle
+++ b/EnF/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.2'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/EnF/src/main/java/com/enf/EnFApplication.java
+++ b/EnF/src/main/java/com/enf/EnFApplication.java
@@ -2,8 +2,10 @@ package com.enf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class EnFApplication {
 
   public static void main(String[] args) {

--- a/EnF/src/main/java/com/enf/controller/AuthController.java
+++ b/EnF/src/main/java/com/enf/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.enf.controller;
+
+import com.enf.model.dto.request.SignupDTO;
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<ResultResponse> signup(@Valid @RequestBody SignupDTO signupDTO) {
+
+    ResultResponse resultResponse = authService.signup(signupDTO);
+
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+}

--- a/EnF/src/main/java/com/enf/entity/UserEntity.java
+++ b/EnF/src/main/java/com/enf/entity/UserEntity.java
@@ -1,0 +1,37 @@
+package com.enf.entity;
+
+import com.enf.model.type.AgeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "Users")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class UserEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userId;
+
+  private String email;
+
+  private String password;
+
+  private String nickname;
+
+  private String tel;
+
+  @Enumerated(EnumType.STRING)
+  private AgeType ageType;
+
+}

--- a/EnF/src/main/java/com/enf/model/dto/request/SignupDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/SignupDTO.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter

--- a/EnF/src/main/java/com/enf/model/dto/request/SignupDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/SignupDTO.java
@@ -1,0 +1,41 @@
+package com.enf.model.dto.request;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class SignupDTO {
+
+  @Email(message = "이메일 형식이 아닙니다.")
+  @JsonProperty("email")
+  private String email;
+
+  @NotEmpty(message = "비밀번호를 입력해주세요.")
+  @JsonProperty("password")
+  private String password;
+
+  @NotEmpty(message = "닉네임을 입력해주세요.")
+  @JsonProperty("nickname")
+  private String nickname;
+
+  @NotEmpty(message = "전화번호를 입력해주세요")
+  @JsonProperty("tel")
+  private String tel;
+
+  @NotEmpty(message = "생년월일")
+  @JsonProperty("birthday")
+  private String birthday;
+
+  @JsonCreator
+  public SignupDTO(String email, String password, String nickname, String tel) {
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+    this.tel = tel;
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/ResultResponse.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/ResultResponse.java
@@ -1,0 +1,39 @@
+package com.enf.model.dto.response;
+
+
+import com.enf.model.type.FailedResultType;
+import com.enf.model.type.SuccessResultType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResultResponse {
+
+  private final Integer code;
+  private final HttpStatus status;
+  private final String message;
+  private final Object data;
+
+  public ResultResponse(SuccessResultType successResultCode, Object data) {
+    this.code = successResultCode.getStatus().value();
+    this.status = successResultCode.getStatus();
+    this.message = successResultCode.getMessage();
+    this.data = data;
+  }
+
+  public ResultResponse(FailedResultType failedResultCode,  Object data) {
+    this.code = failedResultCode.getStatus().value();
+    this.status = failedResultCode.getStatus();
+    this.message = failedResultCode.getMessage();
+    this.data = data;
+  }
+
+  public static ResultResponse of(SuccessResultType successResultCode) {
+    return new ResultResponse(successResultCode, null);
+  }
+
+  public static ResultResponse of(FailedResultType failedResultCode) {
+    return new ResultResponse(failedResultCode, null);
+  }
+
+}

--- a/EnF/src/main/java/com/enf/model/type/AgeType.java
+++ b/EnF/src/main/java/com/enf/model/type/AgeType.java
@@ -1,0 +1,7 @@
+package com.enf.model.type;
+
+public enum AgeType {
+  YOUTH,   // 청년층
+  SENIOR;  // 시니어층
+
+}

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -1,0 +1,16 @@
+package com.enf.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FailedResultType {
+  ;
+
+
+  private final HttpStatus status;
+  private final String message;
+
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -1,0 +1,16 @@
+package com.enf.model.type;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessResultType {
+  SUCCESS_SIGNUP(HttpStatus.OK, "회원가입 성공")
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/EnF/src/main/java/com/enf/repository/UserRepository.java
+++ b/EnF/src/main/java/com/enf/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.enf.repository;
+
+import com.enf.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+
+}

--- a/EnF/src/main/java/com/enf/service/AuthService.java
+++ b/EnF/src/main/java/com/enf/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.enf.service;
+
+import com.enf.model.dto.request.SignupDTO;
+import com.enf.model.dto.response.ResultResponse;
+
+public interface AuthService {
+
+  ResultResponse signup(SignupDTO signupDTO);
+
+}

--- a/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
@@ -1,0 +1,48 @@
+package com.enf.service.impl;
+
+import com.enf.entity.UserEntity;
+import com.enf.model.dto.request.SignupDTO;
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.type.AgeType;
+import com.enf.model.type.SuccessResultType;
+import com.enf.repository.UserRepository;
+import com.enf.service.AuthService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+  private final UserRepository userRepository;
+
+  /**
+   * 회원가입 기능
+   *
+   * SignupDTO : email, password, nickname, tel, birthday
+   *
+   * (임시)
+   * AgeType : SENIOR, YOUTH
+   * SENIOR : birthday가 올해를 기준으로 40 초과일 경우
+   * YOUTH : birthday가 올해를 기준으로 40 미만일 경우
+   */
+  @Override
+  public ResultResponse signup(SignupDTO signupDTO) {
+
+    userRepository.save(UserEntity.builder()
+        .email(signupDTO.getEmail())
+        .password(signupDTO.getPassword())
+        .nickname(signupDTO.getNickname())
+        .tel(signupDTO.getTel())
+        .ageType(LocalDate.parse(signupDTO.getBirthday()).isBefore(LocalDate.now().minusYears(40))
+            ? AgeType.SENIOR
+            : AgeType.YOUTH)
+        .build());
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_SIGNUP);
+  }
+}

--- a/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
@@ -8,7 +8,6 @@ import com.enf.model.type.SuccessResultType;
 import com.enf.repository.UserRepository;
 import com.enf.service.AuthService;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
## 회원가입

### Ⅰ 회원가입 정보 처리

   - AuthController : 로그인 요청 및 인증 코드 처리 엔드포인트 구현
   - AuthService : 사용자 관련 기능을 정의하는 인터페이스 추가
   - AuthServiceImpl : 사용자 관련 로직을 포함한 서비스 클래스 구현
   - UserEntity : 사용자 정보를 저장하는 JPA 엔티티 구현
      - email : 사용자 이메일
      - password : 사용자 비밀번호
      - nickname : 사용자 닉네임
      - tel : 사용자 전화번호
      - birthday : 사용자 생년월일 
   - UserRepository : 사용자 정보를 관리하는 JPA Repository 추가
   - SignupDTO : 사용자 정보를 담는 DTO 생성 



### Ⅱ 응답 클래스 추가
   
   - FailedResultType, SuccessResultType : API 응답의 결과 유형을 정의하는 Enum 클래스 추가
   - ResultResponse : API 응답을 표준화하기 위한 응답 클래스 생성

### Ⅲ 기타 설정 및 유틸리티 추가

   - build.gradle : Spring Boot 버전 변경 (3.4.2 -> 3.3.4)
      - 변경이유 : Hibernate 버전이 6.x 로 업그레이드 되면서 mysql 드라이버를 인식하지 못하는 버그 발생
   - AgeType : 사용자의 연령대를 구분하기 위한 Enum 클래스
      - YOUTH : 청년층
      - SENIOR : 장년층
   - 환경 설정 및 JPA 관련 어노테이션 추가
   - 불필요한 import 정리

## 스크린샷

## 주의사항
- 아직 회원가입 기능에 대한 구체적인 내용이 정해지지 않아서, 추후에 수정할 예정
- 기능 구체화 후 Spring Security 및 JWT 도입 예정
- 기능 구체화 후 테스트 코드 작성 예정

Closes #5 
