### PR TITLE
[feat] 커스텀 예외 처리클래스 및 요청에 대한 응답 클래스 구현

### DIFF
--- a/EnF/src/main/java/com/enf/exception/GlobalException.java
+++ b/EnF/src/main/java/com/enf/exception/GlobalException.java
@@ -1,0 +1,17 @@
+package com.enf.exception;
+
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.type.FailedResultType;
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+  private final ResultResponse resultResponse;
+
+  public GlobalException(FailedResultType failedResultCode) {
+    super("");
+    this.resultResponse = ResultResponse.of(failedResultCode);
+  }
+
+}

--- a/EnF/src/main/java/com/enf/exception/GlobalExceptionHandler.java
+++ b/EnF/src/main/java/com/enf/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.enf.exception;
+
+import com.enf.model.dto.response.ResultResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+  @ExceptionHandler(GlobalException.class)
+  public ResponseEntity<ResultResponse> handleGlobalException(GlobalException ex) {
+    ResultResponse resultResponse = ex.getResultResponse();
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/ResultResponse.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/ResultResponse.java
@@ -1,0 +1,40 @@
+package com.enf.model.dto.response;
+
+import com.enf.model.type.FailedResultType;
+import com.enf.model.type.SuccessResultType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResultResponse {
+
+  private final Integer code;
+  private final HttpStatus status;
+  private final String message;
+  private final Object data;
+
+  // 요청 응답 시 반환할 데이터가 존재 할 경우
+  public ResultResponse(SuccessResultType successResultCode, Object data) {
+    this.code = successResultCode.getStatus().value();
+    this.status = successResultCode.getStatus();
+    this.message = successResultCode.getMessage();
+    this.data = data;
+  }
+
+  public ResultResponse(FailedResultType failedResultCode,  Object data) {
+    this.code = failedResultCode.getStatus().value();
+    this.status = failedResultCode.getStatus();
+    this.message = failedResultCode.getMessage();
+    this.data = data;
+  }
+
+  // 요청 응답 시 반환할 데이터가 존재하지 않을 경우
+  public static ResultResponse of(SuccessResultType successResultCode) {
+    return new ResultResponse(successResultCode, null);
+  }
+
+  public static ResultResponse of(FailedResultType failedResultCode) {
+    return new ResultResponse(failedResultCode, null);
+  }
+
+}

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -1,0 +1,14 @@
+package com.enf.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FailedResultType {
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -1,0 +1,14 @@
+package com.enf.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessResultType {
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
GlobalException : 커스텀 예외 처리 클래스
- RuntimeException을 상속해서 **런타임 예외**로 동작
- 생성자로 FailedResultType을 받아서, 그 정보를 바탕으로 ResultResponse.of(...)를 생성한다.

GlobalExceptionHandler : @RestControllerAdvice를 달아서, 스프링 MVC 전역에서 발생하는 예외를 처리하는 클래스
- handleGlobalException(GlobalException ex) 메서드는 @ExceptionHandler(GlobalException.class)로 등록되어, GlobalException   발생할 때마다 이 메서드를 통해 예외를 처리한다
- 예외 객체(ex)에서 ResultResponse를 꺼낸 뒤, ResponseEntity<ResultResponse> 형태로 HTTP 응답을 작성해서 클라이언트로 반환한다.

SuccessResultType 
- Enum 필드명(반환할 상태 코드값, 반환할 메시지)

FailedResultType 
- Enum 필드명(반환할 상태 코드값, 반환할 메시지)

ResultResponse : 클라이언트 측에 최종으로 반환할 Response 클래스
## 스크린샷

## 주의사항

Closes #13 
