### PR TITLE
[feat] 닉네임 중복 검증 API 구현

### DIFF
--- a/EnF/build.gradle
+++ b/EnF/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.2'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/EnF/src/main/java/com/enf/controller/UserController.java
+++ b/EnF/src/main/java/com/enf/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.enf.controller;
+
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+  private final UserService userService;
+
+  @GetMapping("/check-nickname")
+  public ResponseEntity<ResultResponse> checkNickname(@RequestParam("nickname") String nickname) {
+
+    ResultResponse response = userService.checkNickname(nickname);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/EnF/src/main/java/com/enf/entity/UserEntity.java
+++ b/EnF/src/main/java/com/enf/entity/UserEntity.java
@@ -1,0 +1,42 @@
+package com.enf.entity;
+
+import com.enf.model.type.RoleType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "tb_user")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class UserEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userSeq;
+
+  private String email;
+
+  private String nickname;
+
+  private String age;
+
+  private String providerId;
+
+  @Enumerated(EnumType.STRING)
+  private RoleType role;
+
+  private LocalDate createAt;
+
+  private LocalDate lastLoginAt;
+
+}

--- a/EnF/src/main/java/com/enf/model/type/RoleType.java
+++ b/EnF/src/main/java/com/enf/model/type/RoleType.java
@@ -1,0 +1,8 @@
+package com.enf.model.type;
+
+public enum RoleType {
+  DEVELOPER,  // 개발자
+  ADMIN,      // 관리자
+  YOUTH,      // 청년층
+  SENIOR      // 장년층
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SuccessResultType {
+  SUCCESS_CHECK_NICKNAME(HttpStatus.OK, "닉네임 중복 체크 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/UserRepository.java
+++ b/EnF/src/main/java/com/enf/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.enf.repository;
+
+import com.enf.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+  boolean existsByNickname(String nickname);
+
+}

--- a/EnF/src/main/java/com/enf/service/UserService.java
+++ b/EnF/src/main/java/com/enf/service/UserService.java
@@ -1,0 +1,9 @@
+package com.enf.service;
+
+import com.enf.model.dto.response.ResultResponse;
+
+public interface UserService {
+
+  ResultResponse checkNickname(String nickname);
+
+}

--- a/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
@@ -28,11 +28,11 @@ public class UserServiceImpl implements UserService {
   public ResultResponse checkNickname(String nickname) {
 
     if (userRepository.existsByNickname(nickname)) {
-      log.info("{{} : 중복된 닉네임", nickname);
+      log.info("{} : 중복된 닉네임", nickname);
       return new ResultResponse(SuccessResultType.SUCCESS_CHECK_NICKNAME, true);
     }
 
-    log.info("{{} : 사용가능한 닉네임", nickname);
+    log.info("{} : 사용가능한 닉네임", nickname);
     return new ResultResponse(SuccessResultType.SUCCESS_CHECK_NICKNAME, false);
   }
 }

--- a/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
@@ -1,0 +1,38 @@
+package com.enf.service.impl;
+
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.type.SuccessResultType;
+import com.enf.repository.UserRepository;
+import com.enf.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+
+  /**
+   * 회원가입 or 회원정보 수정시 닉네임 중복 검증을 위한 메서드
+   *
+   * @param nickname 클라이언트 측으로 부터 전달 받은 nickname 값
+   *
+   * @return {@link ResultResponse}
+   * - 중복인 닉네임인 경우 ture
+   * - 사용가능 닉네임인 경우 false
+   */
+  @Override
+  public ResultResponse checkNickname(String nickname) {
+
+    if (userRepository.existsByNickname(nickname)) {
+      log.info("{{} : 중복된 닉네임", nickname);
+      return new ResultResponse(SuccessResultType.SUCCESS_CHECK_NICKNAME, true);
+    }
+
+    log.info("{{} : 사용가능한 닉네임", nickname);
+    return new ResultResponse(SuccessResultType.SUCCESS_CHECK_NICKNAME, false);
+  }
+}

--- a/EnF/src/test/java/com/enf/service/impl/UserServiceImplTest.java
+++ b/EnF/src/test/java/com/enf/service/impl/UserServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.enf.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.type.SuccessResultType;
+import com.enf.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+  // mock 객체
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  // 상수 데이터
+  private final String NICKNAME = "nickname";
+
+
+  // test
+  @Test
+  @DisplayName("닉네임 중복 체크 성공 : 중복된 닉네임")
+  void checkNickname_duplicate() {
+    // given
+    when(userRepository.existsByNickname(NICKNAME)).thenReturn(true);
+
+    // when
+    ResultResponse response = userService.checkNickname(NICKNAME);
+
+    // then
+    assertEquals(SuccessResultType.SUCCESS_CHECK_NICKNAME.getStatus(), response.getStatus());
+    assertEquals(true, response.getData());
+  }
+
+  @Test
+  @DisplayName("닉네임 중복 체크 성공 : 사용가능한 닉네임")
+  void checkNickname_available() {
+    // given
+    when(userRepository.existsByNickname(NICKNAME)).thenReturn(false);
+
+    // when
+    ResultResponse response = userService.checkNickname(NICKNAME);
+
+    // then
+    assertEquals(SuccessResultType.SUCCESS_CHECK_NICKNAME.getStatus(), response.getStatus());
+    assertEquals(false, response.getData());
+  }
+
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원가입 또는 회원정보 수정시 닉네임 중복 검증을 위한 API 구현

#### build.gradle : Spring Boot 버전 변경
- Spring Boot 3.4.2 버전에서 Hibernate가 MySQL 드라이버를 인식하지 못하는 이슈 발생.
- 3.4.2 -> 3.3.4 버전으로 다운그레이드

#### UserEntity : User 테이블과 매핑되는 Entity 클래스 구현
- User 엔티티 생성 및 테이블과 매핑하여 사용자 정보를 관리할 수 있도록 설정.

#### UserRepository : User 테이블에 접근하기 위한 Repository 인터페이스 구현
- JPA 기반의 UserRepository를 생성하여 데이터베이스에서 사용자 정보를 조회 및 관리.

#### RoleType : 사용자 역할을 관리하는 Enum 클래스 구현
- UserRole Enum을 추가하여 사용자 권한을 명확히 구분.
    - DEVELOPER : 개발자
    - AMIN : 관리자
    - YOUTH : 청년층
    - SENIOR : 장년층

#### UserController : 클라이언트 요청을 받아 닉네임 중복 여부를 확인하는 API를 제공하는 클래스
- 클라이언트 측으로 부터 Query Params로 nickname 값을 전달 받는다

#### UserService & UserServiceImpl : 닉네임이 중복되는지 데이터베이스에서 검사하고, 결과를 반환하는 클래스
- 중복된 닉네임일 경우 true
- 사용가능한 닉네임일 경우 false

#### SuccessResultType : 닉네임 중복 체크 성공 시 상태코드 추가
- 중복 검사를 수행한 후, 성공 시 반환할 상태 코드 값을 추가하여 API 응답을 명확히 구분.

#### UserServiceImplTest : 닉네임 중복 체크 테스트 코드 작성
- UserServiceTest에 닉네임 중복 검사에 대한 단위 테스트 추가.


## 스크린샷

### Swagger Test

#### 중복된 닉네임
![image](https://github.com/user-attachments/assets/bbbd7c37-12d6-42ef-85dd-08683dc9c4a3)

#### 사용가능한 닉네임
![image](https://github.com/user-attachments/assets/eafc2e29-9018-4abb-ada1-60d1854d748b)


### Test Code
![image](https://github.com/user-attachments/assets/287a7212-1d17-489e-a7a4-401364a9246c)

## 주의사항

Closes #15 
