### PR TITLE
[feat] 회원 가입 후 사용자 추가 정보 저장을 위한 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/controller/UserController.java
+++ b/EnF/src/main/java/com/enf/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.enf.controller;
 
+import com.enf.model.dto.request.user.AdditionalInfoDTO;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +24,15 @@ public class UserController {
   public ResponseEntity<ResultResponse> checkNickname(@RequestParam("nickname") String nickname) {
 
     ResultResponse response = userService.checkNickname(nickname);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PostMapping("/additional-info")
+  public ResponseEntity<ResultResponse> additionalInfo(
+      HttpServletRequest request, @RequestBody AdditionalInfoDTO additionalInfoDTO) {
+
+    ResultResponse response = userService.additionalInfo(request, additionalInfoDTO);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/EnF/src/main/java/com/enf/entity/BirdEntity.java
+++ b/EnF/src/main/java/com/enf/entity/BirdEntity.java
@@ -1,0 +1,32 @@
+package com.enf.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "bird")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class BirdEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long birdSeq;
+
+  private String birdName;
+
+  private String explanation;
+
+  private String traits1;
+
+  private String traits2;
+
+  private String traits3;
+}

--- a/EnF/src/main/java/com/enf/entity/CategoryEntity.java
+++ b/EnF/src/main/java/com/enf/entity/CategoryEntity.java
@@ -1,0 +1,36 @@
+package com.enf.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "category")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CategoryEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long categorySeq;
+
+  private boolean business;      // 금전/사업
+
+  private boolean job;           // 직장/이직
+
+  private boolean dating;        // 연애상담
+
+  private boolean relationship;  // 대인관계
+
+  private boolean career;        // 취업/진로
+
+  private boolean lifestyle;     // 일상생활
+
+  private boolean other;          // 기타
+}

--- a/EnF/src/main/java/com/enf/entity/UserEntity.java
+++ b/EnF/src/main/java/com/enf/entity/UserEntity.java
@@ -1,12 +1,16 @@
 package com.enf.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity(name = "user")
 @AllArgsConstructor
@@ -19,19 +23,27 @@ public class UserEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long userSeq;
 
-  private String email;
-
-  private String nickname;
-
-  private String age;
-
-  private String provider;
-
-  private String providerId;
+  @ManyToOne
+  @JoinColumn(name = "bird_seq")
+  private BirdEntity bird;
 
   @ManyToOne
   @JoinColumn(name = "role_seq")
   private RoleEntity role;
+
+  @ManyToOne
+  @JoinColumn(name = "category_seq")
+  private CategoryEntity category;
+
+  private String email;
+
+  private String nickname;
+
+  private int birth;
+
+  private String provider;
+
+  private String providerId;
 
   private LocalDateTime createAt;
 

--- a/EnF/src/main/java/com/enf/model/dto/request/user/AdditionalInfoDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/user/AdditionalInfoDTO.java
@@ -1,0 +1,58 @@
+package com.enf.model.dto.request.user;
+
+import com.enf.entity.BirdEntity;
+import com.enf.entity.CategoryEntity;
+import com.enf.entity.RoleEntity;
+import com.enf.entity.UserEntity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class AdditionalInfoDTO {
+
+  @JsonProperty("birdName")
+  private String birdName;
+
+  @JsonProperty("nickname")
+  private String nickname;
+
+  @JsonProperty("birth")
+  private int birth;
+
+  @JsonProperty("ageGroup")
+  private String ageGroup;
+
+  @JsonProperty("userCategory")
+  private UserCategoryDTO userCategory;
+
+  @JsonCreator
+  public AdditionalInfoDTO(String birdName, String nickname,
+      int birth, String ageGroup, UserCategoryDTO userCategory) {
+
+    this.birdName = birdName;
+    this.nickname = nickname;
+    this.birth = birth;
+    this.ageGroup = ageGroup;
+    this.userCategory = userCategory;
+  }
+
+
+  public static UserEntity of(UserEntity user, BirdEntity bird, RoleEntity role,
+      CategoryEntity category, AdditionalInfoDTO additionalInfoDTO) {
+
+    return UserEntity.builder()
+        .userSeq(user.getUserSeq())
+        .bird(bird)
+        .role(role)
+        .category(category)
+        .email(user.getEmail())
+        .nickname(additionalInfoDTO.getNickname())
+        .birth(additionalInfoDTO.getBirth())
+        .provider(user.getProvider())
+        .providerId(user.getProviderId())
+        .createAt(user.getCreateAt())
+        .lastLoginAt(user.getLastLoginAt())
+        .build();
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/request/user/UserCategoryDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/user/UserCategoryDTO.java
@@ -1,0 +1,58 @@
+package com.enf.model.dto.request.user;
+
+import com.enf.entity.CategoryEntity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class UserCategoryDTO {
+
+  @JsonProperty("business")
+  private boolean business;      // 금전/사업
+
+  @JsonProperty("job")
+  private boolean job;           // 직장/이직
+
+  @JsonProperty("dating")
+  private boolean dating;        // 연애상담
+
+  @JsonProperty("relationship")
+  private boolean relationship;  // 대인관계
+
+  @JsonProperty("career")
+  private boolean career;        // 취업/진로
+
+  @JsonProperty("lifestyle")
+  private boolean lifestyle;     // 일상생활
+
+  @JsonProperty("other")
+  private boolean other;          // 기타
+
+  @JsonCreator
+  public UserCategoryDTO(boolean business, boolean job, boolean dating,
+      boolean relationship, boolean career, boolean lifestyle, boolean other) {
+
+    this.business = business;
+    this.job = job;
+    this.dating = dating;
+    this.relationship = relationship;
+    this.career = career;
+    this.lifestyle = lifestyle;
+    this.other = other;
+  }
+
+
+  public static CategoryEntity of(UserCategoryDTO userCategoryDTO) {
+    return CategoryEntity.builder()
+        .business(userCategoryDTO.isBusiness())
+        .job(userCategoryDTO.isJob())
+        .dating(userCategoryDTO.isDating())
+        .relationship(userCategoryDTO.isRelationship())
+        .career(userCategoryDTO.isCareer())
+        .lifestyle(userCategoryDTO.isLifestyle())
+        .other(userCategoryDTO.isOther())
+        .build();
+  }
+
+}

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -10,6 +10,7 @@ public enum FailedResultType {
 
   ACCESS_TOKEN_RETRIEVAL(HttpStatus.UNAUTHORIZED, "액세스 토큰을 가져오는 데 실패했습니다."),
   USER_INFO_RETRIEVAL(HttpStatus.UNAUTHORIZED, "사용자 정보를 가져오는 데 실패했습니다."),
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 회원입니다.")
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -10,6 +10,7 @@ public enum SuccessResultType {
   SUCCESS_KAKAO_LOGIN(HttpStatus.OK, "로그인 성공"),
   SUCCESS_KAKAO_SIGNUP(HttpStatus.OK, "회원가입 성공"),
   SUCCESS_CHECK_NICKNAME(HttpStatus.OK, "닉네임 중복 체크 성공"),
+  SUCCESS_ADDITIONAL_USER_INFO(HttpStatus.OK, "추가 정보 입력 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/BirdRepository.java
+++ b/EnF/src/main/java/com/enf/repository/BirdRepository.java
@@ -1,0 +1,12 @@
+package com.enf.repository;
+
+import com.enf.entity.BirdEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BirdRepository extends JpaRepository<BirdEntity, Long> {
+
+  BirdEntity findByBirdName(String birdName);
+
+}

--- a/EnF/src/main/java/com/enf/repository/CategoryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.enf.repository;
+
+import com.enf.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+
+}

--- a/EnF/src/main/java/com/enf/repository/RoleRepository.java
+++ b/EnF/src/main/java/com/enf/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.enf.repository;
+
+import com.enf.entity.RoleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<RoleEntity, Long> {
+
+  RoleEntity findByRoleName(String roleName);
+
+}

--- a/EnF/src/main/java/com/enf/repository/UserRepository.java
+++ b/EnF/src/main/java/com/enf/repository/UserRepository.java
@@ -5,10 +5,10 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
-
-  UserEntity findByEmail(String email);
 
   boolean existsByProviderId(String providerId);
 

--- a/EnF/src/main/java/com/enf/service/UserService.java
+++ b/EnF/src/main/java/com/enf/service/UserService.java
@@ -1,9 +1,12 @@
 package com.enf.service;
 
+import com.enf.model.dto.request.user.AdditionalInfoDTO;
 import com.enf.model.dto.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
 
   ResultResponse checkNickname(String nickname);
 
+  ResultResponse additionalInfo(HttpServletRequest request, AdditionalInfoDTO additionalInfoDTO);
 }

--- a/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
@@ -1,9 +1,21 @@
 package com.enf.service.impl;
 
+import com.enf.entity.BirdEntity;
+import com.enf.entity.CategoryEntity;
+import com.enf.entity.RoleEntity;
+import com.enf.entity.UserEntity;
+import com.enf.exception.GlobalException;
+import com.enf.model.dto.request.user.AdditionalInfoDTO;
+import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.type.FailedResultType;
 import com.enf.model.type.SuccessResultType;
+import com.enf.repository.BirdRepository;
+import com.enf.repository.CategoryRepository;
+import com.enf.repository.RoleRepository;
 import com.enf.repository.UserRepository;
 import com.enf.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +26,9 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
+  private final BirdRepository birdRepository;
+  private final RoleRepository roleRepository;
+  private final CategoryRepository categoryRepository;
 
   /**
    * 회원가입 or 회원정보 수정시 닉네임 중복 검증을 위한 메서드
@@ -34,5 +49,26 @@ public class UserServiceImpl implements UserService {
 
     log.info("{} : 사용가능한 닉네임", nickname);
     return new ResultResponse(SuccessResultType.SUCCESS_CHECK_NICKNAME, false);
+  }
+
+  @Override
+  public ResultResponse additionalInfo(HttpServletRequest request,
+      AdditionalInfoDTO additionalInfoDTO) {
+
+    // 사용자 정보 추출, 추후 Jwt 토큰 로직 구현 후 수정할 예정
+    UserEntity user = userRepository.findById(1L)
+        .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
+
+    BirdEntity bird = birdRepository.findByBirdName(additionalInfoDTO.getBirdName());
+
+    RoleEntity role = roleRepository.findByRoleName(additionalInfoDTO.getAgeGroup());
+
+    CategoryEntity category = role.getRoleName().equals("senior")
+        ? categoryRepository.save(UserCategoryDTO.of(additionalInfoDTO.getUserCategory()))
+        : null;
+
+    userRepository.save(AdditionalInfoDTO.of(user, bird, role, category, additionalInfoDTO));
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_ADDITIONAL_USER_INFO);
   }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원 가입 후 사용자 추가 정보 저장을 위한 API 구현
#### UserController.java
   - 사용자 추가 정보를 입력받는 API(/additional-info) 추가.
#### BirdEntity.java
   - 사용자가 선호하는 새 정보를 저장하기 위한 엔티티 생성.
   - birdName, explanation, traits1~3 필드를 포함.
#### CategoryEntity.java
   - 사용자의 관심 카테고리를 저장하기 위한 엔티티 생성.
   - 금전/사업, 직장/이직, 연애, 대인관계, 취업/진로, 일상생활, 기타 카테고리 포함.
#### UserEntity.java
   - BirdEntity, CategoryEntity와 연관 관계 추가.
   - 사용자의 추가 정보를 저장하기 위한 필드(bird, category) 추가.
#### AdditionalInfoDTO.java
   - 사용자 추가 정보 요청을 위한 DTO 생성.
   - birdName, nickname, birth, ageGroup, userCategory 필드를 포함.
#### UserCategoryDTO.java
   - CategoryEntity 데이터를 생성하기 위한 DTO 추가.
   - 사용자가 선택한 관심 카테고리를 변환하는 기능 제공.
#### FailedResultType.java / SuccessResultType.java
   - 사용자 정보 입력 성공 및 실패 응답을 Enum으로 추가.
#### BirdRepository.java / CategoryRepository.java / RoleRepository.java
   - 새, 카테고리, 역할 정보를 조회 및 저장하기 위한 JPA Repository 추가.
#### UserService.java / UserServiceImpl.java
   - 사용자 추가 정보 저장 로직 구현.
   - 사용자의 birdName, role, category 정보를 조회하여 저장.
   - role이 senior인 경우 CategoryEntity를 새로 저장하도록 처리.

## 스크린샷

### 청년층
![image](https://github.com/user-attachments/assets/1980b4a5-5571-467e-b7fa-1071c85afddf)

### 장년층
![image](https://github.com/user-attachments/assets/d1dabaa8-b523-4cd7-80d0-1f5b6729f014)


## 주의사항
1. 구현된 클래스가 많아 커밋 단위로 봐주시면 감사하겠습니다!! 
2. 로직 수정과 Test 코드는 JWT 토큰을 생성하는 로직이 구현이 되면 작성할 예정입니다.!
3. 해당 코드를 테스트 하기 위해서는 SecurityConstants 클래스에 해당 API 를 등록하시면 됩니다!

##
Closes #19 
