### PR TITLE
[feat] 사용자 정보 조회 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/controller/UserController.java
+++ b/EnF/src/main/java/com/enf/controller/UserController.java
@@ -37,4 +37,12 @@ public class UserController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/info")
+  public ResponseEntity<ResultResponse> userInfo(HttpServletRequest request) {
+
+    ResultResponse response = userService.userInfo(request);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/user/UserCategoryDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/user/UserCategoryDTO.java
@@ -55,4 +55,16 @@ public class UserCategoryDTO {
         .build();
   }
 
+  public static UserCategoryDTO of(CategoryEntity category) {
+    return new UserCategoryDTO(
+        category.isBusiness(),
+        category.isJob(),
+        category.isDating(),
+        category.isRelationship(),
+        category.isCareer(),
+        category.isLifestyle(),
+        category.isOther()
+    );
+  }
+
 }

--- a/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
@@ -1,6 +1,7 @@
 package com.enf.model.dto.response.user;
 
 import com.enf.entity.UserEntity;
+import com.enf.model.dto.request.user.UserCategoryDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,12 +17,18 @@ public class UserInfoDTO {
 
   private String roleName;
 
+  private UserCategoryDTO userCategory;
+
 
   public static UserInfoDTO of(UserEntity user) {
     return new UserInfoDTO(
         user.getBird().getBirdName(),
         user.getNickname(),
-        user.getRole().getRoleName());
+        user.getRole().getRoleName(),
+        user.getRole().getRoleName().equals("senior")
+            ? UserCategoryDTO.of(user.getCategory())
+            : null);
+
   }
 
 }

--- a/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
@@ -1,0 +1,27 @@
+package com.enf.model.dto.response.user;
+
+import com.enf.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoDTO {
+
+  private String birdName;
+
+  private String nickname;
+
+  private String roleName;
+
+
+  public static UserInfoDTO of(UserEntity user) {
+    return new UserInfoDTO(
+        user.getBird().getBirdName(),
+        user.getNickname(),
+        user.getRole().getRoleName());
+  }
+
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -11,6 +11,7 @@ public enum SuccessResultType {
   SUCCESS_KAKAO_SIGNUP(HttpStatus.OK, "회원가입 성공"),
   SUCCESS_CHECK_NICKNAME(HttpStatus.OK, "닉네임 중복 체크 성공"),
   SUCCESS_ADDITIONAL_USER_INFO(HttpStatus.OK, "추가 정보 입력 성공"),
+  SUCCESS_GET_USER_INFO(HttpStatus.OK, "회원 정보 조회 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/service/UserService.java
+++ b/EnF/src/main/java/com/enf/service/UserService.java
@@ -9,4 +9,6 @@ public interface UserService {
   ResultResponse checkNickname(String nickname);
 
   ResultResponse additionalInfo(HttpServletRequest request, AdditionalInfoDTO additionalInfoDTO);
+
+  ResultResponse userInfo(HttpServletRequest request);
 }

--- a/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.user.AdditionalInfoDTO;
 import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.dto.response.user.UserInfoDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.SuccessResultType;
 import com.enf.repository.BirdRepository;
@@ -70,5 +71,15 @@ public class UserServiceImpl implements UserService {
     userRepository.save(AdditionalInfoDTO.of(user, bird, role, category, additionalInfoDTO));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_ADDITIONAL_USER_INFO);
+  }
+
+  @Override
+  public ResultResponse userInfo(HttpServletRequest request) {
+    UserEntity user = userRepository.findById(1L)
+        .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
+
+    UserInfoDTO userInfo = UserInfoDTO.of(user);
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_USER_INFO, userInfo);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

사용자 정보 조회 API 구현

#### UserController.java
   - 사용자 정보를 조회하는 API(/info) 추가.
   - 요청을 받아 userService.userInfo()를 호출하여 사용자 정보를 반환.
#### UserInfoDTO.java
   - 사용자 정보를 담는 DTO 생성.
   - birdName, nickname, roleName 정보를 포함.
   - UserEntity에서 데이터를 변환하는 of() 메서드 추가.
#### SuccessResultType.java
   - 사용자 정보 조회 성공 응답을 Enum(SUCCESS_GET_USER_INFO)으로 추가.
#### UserService.java
   - 사용자 정보 조회 메서드(userInfo)를 인터페이스에 추가.
#### UserServiceImpl.java
   - 사용자 정보 조회 로직 구현.
   - UserEntity를 조회하여 UserInfoDTO로 변환 후 반환.
   - 사용자 정보가 존재하지 않으면 USER_NOT_FOUND 예외 발생.

## 스크린샷
![image](https://github.com/user-attachments/assets/2beaecf4-bdf1-4a1e-9f07-6483978c0f7b)

## 주의사항

Closes #24 
