### PR TITLE
[feat] 회원정보 수정 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/controller/UserController.java
+++ b/EnF/src/main/java/com/enf/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.enf.controller;
 
 import com.enf.model.dto.request.user.AdditionalInfoDTO;
+import com.enf.model.dto.request.user.UpdateNicknameDTO;
+import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,6 +35,26 @@ public class UserController {
       HttpServletRequest request, @RequestBody AdditionalInfoDTO additionalInfoDTO) {
 
     ResultResponse response = userService.additionalInfo(request, additionalInfoDTO);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PostMapping("/update/nickname")
+  public ResponseEntity<ResultResponse> updateNickname(
+      HttpServletRequest request,
+      @RequestBody UpdateNicknameDTO nickname) {
+
+    ResultResponse response = userService.updateNickname(request, nickname);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PostMapping("/update/category")
+  public ResponseEntity<ResultResponse> updateCategory(
+      HttpServletRequest request,
+      @RequestBody UserCategoryDTO userCategory) {
+
+    ResultResponse response = userService.updateCategory(request, userCategory);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/EnF/src/main/java/com/enf/controller/UserController.java
+++ b/EnF/src/main/java/com/enf/controller/UserController.java
@@ -39,6 +39,14 @@ public class UserController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/info")
+  public ResponseEntity<ResultResponse> userInfo(HttpServletRequest request) {
+
+    ResultResponse response = userService.userInfo(request);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
   @PostMapping("/update/nickname")
   public ResponseEntity<ResultResponse> updateNickname(
       HttpServletRequest request,
@@ -55,14 +63,6 @@ public class UserController {
       @RequestBody UserCategoryDTO userCategory) {
 
     ResultResponse response = userService.updateCategory(request, userCategory);
-
-    return new ResponseEntity<>(response, response.getStatus());
-  }
-
-  @GetMapping("/info")
-  public ResponseEntity<ResultResponse> userInfo(HttpServletRequest request) {
-
-    ResultResponse response = userService.userInfo(request);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/EnF/src/main/java/com/enf/model/dto/request/user/UpdateNicknameDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/user/UpdateNicknameDTO.java
@@ -1,0 +1,17 @@
+package com.enf.model.dto.request.user;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameDTO {
+
+  @JsonProperty("nickname")
+  private String nickname;
+
+  @JsonCreator
+  public UpdateNicknameDTO(String nickname) {
+    this.nickname = nickname;
+  }
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -11,6 +11,8 @@ public enum SuccessResultType {
   SUCCESS_KAKAO_SIGNUP(HttpStatus.OK, "회원가입 성공"),
   SUCCESS_CHECK_NICKNAME(HttpStatus.OK, "닉네임 중복 체크 성공"),
   SUCCESS_ADDITIONAL_USER_INFO(HttpStatus.OK, "추가 정보 입력 성공"),
+  SUCCESS_UPDATE_NICKNAME(HttpStatus.OK, "닉네임 수정 성공"),
+  SUCCESS_UPDATE_CATEGORY(HttpStatus.OK, "카테고리 수정 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/UserRepository.java
+++ b/EnF/src/main/java/com/enf/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.enf.repository;
 
+import com.enf.entity.CategoryEntity;
 import com.enf.entity.UserEntity;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,5 +21,15 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   void updateLastLoginAtByProviderId(String providerId);
  
   boolean existsByNickname(String nickname);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE user u set u.nickname = :nickname WHERE u.userSeq = :userSeq")
+  void updateNicknameByUserSeq(Long userSeq, String nickname);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE user u set u.category = :category WHERE u.userSeq = :userSeq")
+  void updateCategoryByUserSeq(Long userSeq, CategoryEntity category);
 
 }

--- a/EnF/src/main/java/com/enf/service/UserService.java
+++ b/EnF/src/main/java/com/enf/service/UserService.java
@@ -1,6 +1,8 @@
 package com.enf.service;
 
 import com.enf.model.dto.request.user.AdditionalInfoDTO;
+import com.enf.model.dto.request.user.UpdateNicknameDTO;
+import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -9,4 +11,8 @@ public interface UserService {
   ResultResponse checkNickname(String nickname);
 
   ResultResponse additionalInfo(HttpServletRequest request, AdditionalInfoDTO additionalInfoDTO);
+
+  ResultResponse updateNickname(HttpServletRequest request, UpdateNicknameDTO nickname);
+
+  ResultResponse updateCategory(HttpServletRequest request, UserCategoryDTO userCategory);
 }

--- a/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/UserServiceImpl.java
@@ -6,6 +6,7 @@ import com.enf.entity.RoleEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.user.AdditionalInfoDTO;
+import com.enf.model.dto.request.user.UpdateNicknameDTO;
 import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.model.type.FailedResultType;
@@ -70,5 +71,27 @@ public class UserServiceImpl implements UserService {
     userRepository.save(AdditionalInfoDTO.of(user, bird, role, category, additionalInfoDTO));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_ADDITIONAL_USER_INFO);
+  }
+
+  @Override
+  public ResultResponse updateNickname(HttpServletRequest request, UpdateNicknameDTO nickname) {
+    UserEntity user = userRepository.findById(1L)
+        .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
+
+    userRepository.updateNicknameByUserSeq(user.getUserSeq(), nickname.getNickname());
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_NICKNAME);
+  }
+
+  @Override
+  public ResultResponse updateCategory(HttpServletRequest request, UserCategoryDTO userCategory) {
+    UserEntity user = userRepository.findById(1L)
+        .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
+
+    CategoryEntity category = UserCategoryDTO.of(userCategory);
+
+    userRepository.updateCategoryByUserSeq(user.getUserSeq(), category);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_CATEGORY);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원정보 수정 API 구현

1. 닉네임 수정
2. 카테고리 수정

#### UserController.java
   - 닉네임 변경 API (POST /update/nickname) 추가.
   - 카테고리 변경 API (POST /update/category) 추가.
   - 요청을 받아 userService.updateNickname() 및 userService.updateCategory()를 호출하여 변경된 정보를 반환.
#### UpdateNicknameDTO.java
   - 닉네임 변경 요청을 위한 DTO (UpdateNicknameDTO) 생성.
   - nickname 필드를 포함하며, @JsonProperty 및 @JsonCreator를 추가하여 JSON 요청 처리.
#### SuccessResultType.java
   - 성공 응답 메시지 SUCCESS_UPDATE_NICKNAME, SUCCESS_UPDATE_CATEGORY 추가.
   - 닉네임 및 카테고리 변경 시 성공 응답을 Enum으로 관리.
#### UserRepository.java
   - updateNicknameByUserSeq(Long userSeq, String nickname) 메서드 추가 → 특정 사용자의 닉네임 변경.
   - updateCategoryByUserSeq(Long userSeq, CategoryEntity category) 메서드 추가 → 특정 사용자의 카테고리 변경.
   - @Modifying, @Transactional을 사용하여 UPDATE 쿼리 실행 가능하도록 설정.
#### UserService.java
   - 닉네임 및 카테고리 변경을 위한 인터페이스 메서드 (updateNickname, updateCategory) 추가.
#### UserServiceImpl.java
   - 닉네임 변경 로직 추가:
      - 사용자 조회 (userRepository.findById(1L))
      - 닉네임 변경 (userRepository.updateNicknameByUserSeq(...))
      - 성공 응답 반환 (ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_NICKNAME))
   - 카테고리 변경 로직 추가:
      - 사용자 조회 (userRepository.findById(1L))
      - UserCategoryDTO를 CategoryEntity로 변환
      - 카테고리 변경 (userRepository.updateCategoryByUserSeq(...))
      - 성공 응답 반환 (ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_CATEGORY))

## 스크린샷

## 주의사항

Closes #26 
