### PR TITLE
[refactor] 편지 Entity 수정 및 관련 로직 수정

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -2,6 +2,8 @@ package com.enf.component.facade;
 
 import com.enf.entity.LetterEntity;
 import com.enf.entity.NotificationEntity;
+import com.enf.exception.GlobalException;
+import com.enf.model.type.FailedResultType;
 import com.enf.repository.LetterRepository;
 import com.enf.repository.NotificationRepository;
 import java.util.List;
@@ -52,5 +54,10 @@ public class LetterFacade {
    */
   public void saveLetter(LetterEntity letter) {
     letterRepository.save(letter);
+  }
+
+  public LetterEntity findLetterByLetterSeq(Long letterSeq) {
+    return letterRepository.findByLetterSeq(letterSeq)
+        .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
   }
 }

--- a/EnF/src/main/java/com/enf/component/facade/UserFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/UserFacade.java
@@ -119,8 +119,8 @@ public class UserFacade {
    *
    * @param sendLetter 작성한 편지 정보
    */
-  public UserEntity getReceiveUserByBirdAndCategory(SendLetterDTO sendLetter) {
-    return userQueryRepository.getSendUser(sendLetter.getBirdName(), sendLetter.getCategoryName());
+  public UserEntity getMentorByBirdAndCategory(SendLetterDTO sendLetter) {
+    return userQueryRepository.getMentor(sendLetter.getBirdName(), sendLetter.getCategoryName());
   }
 
   public UserEntity findByNickname(String receiveUser) {

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -1,6 +1,5 @@
 package com.enf.controller;
 
-import com.enf.model.dto.request.letter.ReceiveLetterDTO;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.response.ResultResponse;

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -1,6 +1,7 @@
 package com.enf.controller;
 
 import com.enf.model.dto.request.letter.ReceiveLetterDTO;
+import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.LetterService;
@@ -36,12 +37,12 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
-  @PostMapping("/receive")
-  public ResponseEntity<ResultResponse> receiveLetter(
+  @PostMapping("/reply")
+  public ResponseEntity<ResultResponse> replyLetter(
       HttpServletRequest request,
-      @RequestBody ReceiveLetterDTO receiveLetter) {
+      @RequestBody ReplyLetterDTO reply) {
 
-    ResultResponse response = letterService.receiveLetter(request, receiveLetter);
+    ResultResponse response = letterService.replyLetter(request, reply);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterEntity.java
@@ -24,12 +24,12 @@ public class LetterEntity {
   private Long letterSeq;
 
   @ManyToOne
-  @JoinColumn(name = "send_user_seq")
-  private UserEntity sendUser;
+  @JoinColumn(name = "mentee_seq")
+  private UserEntity mentee;
 
   @ManyToOne
-  @JoinColumn(name = "receive_user_seq")
-  private UserEntity receiveUser;
+  @JoinColumn(name = "mentor_seq")
+  private UserEntity mentor;
 
   private String categoryName;
 
@@ -38,4 +38,8 @@ public class LetterEntity {
   private String letter;
 
   private LocalDateTime createAt;
+
+  @ManyToOne
+  @JoinColumn(name = "reply_to")
+  private LetterEntity replyTo;
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
@@ -8,7 +8,10 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
-public class ReceiveLetterDTO {
+public class ReplyLetterDTO {
+
+  @JsonProperty("menteeLetterSeq")
+  private Long menteeLetterSeq;
 
   @JsonProperty("categoryName")
   private String categoryName;
@@ -23,7 +26,8 @@ public class ReceiveLetterDTO {
   private String letter;
 
   @JsonCreator
-  public ReceiveLetterDTO(String categoryName, String receiveUser, String title, String letter) {
+  public ReplyLetterDTO(Long menteeLetterSeq, String categoryName, String receiveUser, String title, String letter) {
+    this.menteeLetterSeq = menteeLetterSeq;
     this.categoryName = categoryName;
     this.receiveUser = receiveUser;
     this.title = title;
@@ -31,14 +35,14 @@ public class ReceiveLetterDTO {
   }
 
   public static LetterEntity of(UserEntity sendUser,
-      UserEntity receiveUser, ReceiveLetterDTO receiveLetterDTO) {
+      UserEntity receiveUser, ReplyLetterDTO replyLetter) {
 
     return LetterEntity.builder()
         .sendUser(sendUser)
         .receiveUser(receiveUser)
-        .categoryName(receiveLetterDTO.getCategoryName())
-        .letterTitle(receiveLetterDTO.getTitle())
-        .letter(receiveLetterDTO.getLetter())
+        .categoryName(replyLetter.getCategoryName())
+        .letterTitle(replyLetter.getTitle())
+        .letter(replyLetter.getLetter())
         .createAt(LocalDateTime.now())
         .build();
   }

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
@@ -10,8 +10,8 @@ import lombok.Getter;
 @Getter
 public class ReplyLetterDTO {
 
-  @JsonProperty("menteeLetterSeq")
-  private Long menteeLetterSeq;
+  @JsonProperty("letterSeq")
+  private Long letterSeq;
 
   @JsonProperty("categoryName")
   private String categoryName;
@@ -26,24 +26,25 @@ public class ReplyLetterDTO {
   private String letter;
 
   @JsonCreator
-  public ReplyLetterDTO(Long menteeLetterSeq, String categoryName, String receiveUser, String title, String letter) {
-    this.menteeLetterSeq = menteeLetterSeq;
+  public ReplyLetterDTO(Long letterSeq, String categoryName, String receiveUser, String title, String letter) {
+    this.letterSeq = letterSeq;
     this.categoryName = categoryName;
     this.receiveUser = receiveUser;
     this.title = title;
     this.letter = letter;
   }
 
-  public static LetterEntity of(UserEntity sendUser,
-      UserEntity receiveUser, ReplyLetterDTO replyLetter) {
+  public static LetterEntity of(UserEntity mentor, UserEntity mentee, ReplyLetterDTO replyLetter,
+      LetterEntity menteeLetter) {
 
     return LetterEntity.builder()
-        .sendUser(sendUser)
-        .receiveUser(receiveUser)
+        .mentor(mentor)
+        .mentee(mentee)
         .categoryName(replyLetter.getCategoryName())
         .letterTitle(replyLetter.getTitle())
         .letter(replyLetter.getLetter())
         .createAt(LocalDateTime.now())
+        .replyTo(menteeLetter)
         .build();
   }
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
@@ -31,10 +31,10 @@ public class SendLetterDTO {
   }
 
 
-  public static LetterEntity of(UserEntity sendUser, UserEntity receiveUser, SendLetterDTO sendLetter) {
+  public static LetterEntity of(UserEntity mentee, UserEntity mentor, SendLetterDTO sendLetter) {
     return LetterEntity.builder()
-        .sendUser(sendUser)
-        .receiveUser(receiveUser)
+        .mentee(mentee)
+        .mentor(mentor)
         .categoryName(sendLetter.getCategoryName())
         .letterTitle(sendLetter.getTitle())
         .letter(sendLetter.getLetter())

--- a/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
@@ -34,13 +34,24 @@ public class NotificationDTO {
   }
 
   /**
-   * 편지를 보냈을 때 생성되는 알림
+   * 멘티가 편지를 보냈을 때 생성되는 알림
    */
-  public static NotificationDTO sendLetter(UserEntity sendUser, UserEntity receiveUser) {
+  public static NotificationDTO sendLetter(UserEntity mentee, UserEntity mentor) {
     return new NotificationDTO(
-        receiveUser.getUserSeq(),
-        sendUser.getNickname(),
-        sendUser.getNickname() + " 버디가 편지를 보냈어요~"
+        mentor.getUserSeq(),
+        mentee.getNickname(),
+        mentee.getNickname() + " 버디가 편지를 보냈어요~"
+    );
+  }
+
+  /**
+   * 멘토가 편지를 보냈을 때 생성되는 알림
+   */
+  public static NotificationDTO replyLetter(UserEntity mentor, UserEntity mentee) {
+    return new NotificationDTO(
+        mentee.getUserSeq(),
+        mentor.getNickname(),
+        mentor.getNickname() + " 버디가 편지를 보냈어요~"
     );
   }
 
@@ -62,7 +73,7 @@ public class NotificationDTO {
     return new NotificationDTO(
         userSeq,
         notification.getSendUser(),
-        notification.getSendUser() + " 외 " + size + "명의 버디가 편지를 보냈어요~"
+        notification.getSendUser() + "외 " + size + "명의 버디가 편지를 보냈어요~"
     );
   }
 

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -15,6 +15,7 @@ public enum FailedResultType {
   COOKIE_IS_NULL(HttpStatus.FORBIDDEN,"쿠키값이 존재하지 않습니다."),
   REFRESH_TOKEN_IS_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다!"),
   BAD_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "발급된 Refresh 토큰이 아닙니다."),
+  LETTER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 편지 일련번호 입니다."),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterRepository.java
@@ -1,10 +1,13 @@
 package com.enf.repository;
 
 import com.enf.entity.LetterEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LetterRepository extends JpaRepository<LetterEntity, Long> {
+
+  Optional<LetterEntity> findByLetterSeq(Long letterSeq);
 
 }

--- a/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
@@ -27,7 +27,7 @@ public class UserQueryRepository {
    * @param categoryName 카테고리명
    * @return 조건에 맞는 사용자 엔티티
    */
-  public UserEntity getSendUser(String birdName, String categoryName) {
+  public UserEntity getMentor(String birdName, String categoryName) {
 
     // 1순위: 새 유형과 카테고리가 모두 일치하는 사용자
     // 2순위: 카테고리만 일치하는 사용자

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -1,6 +1,6 @@
 package com.enf.service;
 
-import com.enf.model.dto.request.letter.ReceiveLetterDTO;
+import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,5 +9,5 @@ public interface LetterService {
 
   ResultResponse sendLetter(HttpServletRequest request, SendLetterDTO sendLetter);
 
-  ResultResponse receiveLetter(HttpServletRequest request, ReceiveLetterDTO receiveLetter);
+  ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -3,7 +3,7 @@ package com.enf.service.impl;
 import com.enf.component.facade.LetterFacade;
 import com.enf.component.facade.UserFacade;
 import com.enf.entity.UserEntity;
-import com.enf.model.dto.request.letter.ReceiveLetterDTO;
+import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.notification.NotificationDTO;
 import com.enf.model.dto.response.ResultResponse;
@@ -60,15 +60,15 @@ public class LetterServiceImpl implements LetterService {
    * 4. Redis Pub/Sub을 이용해 알림 전송
    *
    * @param request    HTTP 요청 객체 (토큰 확인)
-   * @param receiveLetter 답장을 위해 사용자가 작성한 편지 정보
+   * @param replyLetter 답장을 위해 사용자가 작성한 편지 정보
    * @return 편지 전송 결과 응답 객체
    */
   @Override
-  public ResultResponse receiveLetter(HttpServletRequest request, ReceiveLetterDTO receiveLetter) {
+  public ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter) {
     UserEntity sendUser = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
-    UserEntity receiveUser = userFacade.findByNickname(receiveLetter.getReceiveUser());
+    UserEntity receiveUser = userFacade.findByNickname(replyLetter.getReceiveUser());
 
-    letterFacade.saveLetter(ReceiveLetterDTO.of(receiveUser, sendUser, receiveLetter));
+    letterFacade.saveLetter(ReplyLetterDTO.of(receiveUser, sendUser, replyLetter));
     redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(sendUser, receiveUser));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_RECEIVE_LETTER);

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -2,6 +2,7 @@ package com.enf.service.impl;
 
 import com.enf.component.facade.LetterFacade;
 import com.enf.component.facade.UserFacade;
+import com.enf.entity.LetterEntity;
 import com.enf.entity.UserEntity;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
@@ -42,11 +43,11 @@ public class LetterServiceImpl implements LetterService {
    */
   @Override
   public ResultResponse sendLetter(HttpServletRequest request, SendLetterDTO sendLetter) {
-    UserEntity sendUser = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
-    UserEntity receiveUser = userFacade.getReceiveUserByBirdAndCategory(sendLetter);
+    UserEntity mentee = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+    UserEntity mentor = userFacade.getMentorByBirdAndCategory(sendLetter);
 
-    letterFacade.saveLetter(SendLetterDTO.of(sendUser, receiveUser, sendLetter));
-    redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(sendUser, receiveUser));
+    letterFacade.saveLetter(SendLetterDTO.of(mentee, mentor, sendLetter));
+    redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(mentee, mentor));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_SEND_LETTER);
   }
@@ -65,11 +66,13 @@ public class LetterServiceImpl implements LetterService {
    */
   @Override
   public ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter) {
-    UserEntity sendUser = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
-    UserEntity receiveUser = userFacade.findByNickname(replyLetter.getReceiveUser());
+    UserEntity mentor = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+    UserEntity mentee = userFacade.findByNickname(replyLetter.getReceiveUser());
 
-    letterFacade.saveLetter(ReplyLetterDTO.of(receiveUser, sendUser, replyLetter));
-    redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(sendUser, receiveUser));
+    LetterEntity menteeLetter = letterFacade.findLetterByLetterSeq(replyLetter.getLetterSeq());
+
+    letterFacade.saveLetter(ReplyLetterDTO.of(mentor, mentee, replyLetter, menteeLetter));
+    redisTemplate.convertAndSend("notifications", NotificationDTO.replyLetter(mentor, mentee));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_RECEIVE_LETTER);
   }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

#### LetterEntity 변경
   - sendUser, receiveUser → mentee, mentor로 변경 (역할 명확화)
   - replyTo 필드 추가 (멘토가 특정 편지에 대한 답장을 보낼 수 있도록 처리)
#### LetterServiceImpl 변경
   - sendLetter() → mentee가 mentor에게 새 편지를 보낼 때 사용
   - replyLetter() → mentor가 mentee의 기존 편지에 답장할 때 사용
#### DTO 수정 및 통일화
   - ReceiveLetterDTO → ReplyLetterDTO로 변경 (멘토의 답장 전용 DTO)
   - SendLetterDTO 내부에서 mentee, mentor 개념 반영
#### Facade 및 Repository 개선
   - getReceiveUserByBirdAndCategory() → getMentorByBirdAndCategory()로 변경
   - findLetterByLetterSeq() 추가 (멘토가 답장할 편지 조회)
#### 알림(Notification) 로직 개선
   - sendLetter() → 멘티가 멘토에게 편지를 보낼 때 알림
   - replyLetter() → 멘토가 멘티의 편지에 답장할 때 알림

## 스크린샷

## 주의사항

Closes #40 
