### PR TITLE
[feat] 편지 조회(보관함) API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -1,11 +1,18 @@
 package com.enf.component.facade;
 
 import com.enf.entity.LetterEntity;
+import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.NotificationEntity;
+import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
+import com.enf.model.dto.response.PageResponse;
+import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.repository.LetterRepository;
+import com.enf.repository.LetterStatusRepository;
 import com.enf.repository.NotificationRepository;
+import com.enf.repository.querydsl.LetterQueryRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +25,8 @@ public class LetterFacade {
 
   private final LetterRepository letterRepository;
   private final NotificationRepository notificationRepository;
+  private final LetterStatusRepository letterStatusRepository;
+  private final LetterQueryRepository letterQueryRepository;
 
   /**
    * 특정 사용자의 모든 알림 조회
@@ -48,16 +57,80 @@ public class LetterFacade {
   }
 
   /**
-   * 편지 저장
+   * 멘티가 보낸 편지를 저장하고 편지 상태(LetterStatusEntity)도 함께 저장
    *
    * @param letter 저장할 편지 엔티티
+   * @param mentee 편지를 보낸 멘티
+   * @param mentor 편지를 받는 멘토
    */
-  public void saveLetter(LetterEntity letter) {
-    letterRepository.save(letter);
+  public void saveMenteeLetter(LetterEntity letter, UserEntity mentee, UserEntity mentor) {
+    // 편지를 저장
+    LetterEntity menteeLetter = letterRepository.save(letter);
+
+    // 편지 상태 저장 (멘토가 답장할 때 참조할 수 있도록 함)
+    letterStatusRepository.save(
+        LetterStatusEntity.builder()
+            .mentee(mentee)
+            .mentor(mentor)
+            .menteeLetter(menteeLetter)
+            .createAt(LocalDateTime.now())
+            .build()
+    );
   }
 
+  /**
+   * 멘토가 답장을 보낼 때 편지 저장 및 상태 업데이트
+   *
+   * @param letter 저장할 멘토의 답장 편지 엔티티
+   * @param menteeLetter 멘티가 보낸 원본 편지 엔티티
+   */
+  public void saveMentorLetter(LetterEntity letter, LetterEntity menteeLetter) {
+    // 멘토의 답장 편지를 저장
+    LetterEntity mentorLetter = letterRepository.save(letter);
+
+    // 기존 편지 상태 업데이트 (멘토의 답장을 반영)
+    letterStatusRepository.updateLetterStatus(mentorLetter, menteeLetter);
+  }
+
+  /**
+   * 특정 편지 ID로 편지 조회
+   *
+   * @param letterSeq 조회할 편지의 ID
+   * @return 조회된 LetterEntity 객체
+   * @throws GlobalException 편지가 존재하지 않을 경우 예외 발생
+   */
   public LetterEntity findLetterByLetterSeq(Long letterSeq) {
     return letterRepository.findByLetterSeq(letterSeq)
         .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
+  }
+
+  /**
+   * 특정 사용자의 모든 편지 조회 (멘티와 멘토 구분하여 처리)
+   *
+   * @param user 사용자 엔티티 (멘티 또는 멘토)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 페이지네이션된 편지 목록
+   */
+  public PageResponse<ReceiveLetterDTO> getAllLetterList(UserEntity user, int pageNumber) {
+    // 사용자가 멘티인 경우 멘티의 편지 리스트 반환
+    if (user.getRole().getRoleName().equals("MENTEE")) {
+      return letterQueryRepository.getAllLetterListForMenTee(user, pageNumber);
+    }
+
+    // 사용자가 멘토인 경우 멘토의 편지 리스트 반환
+    return letterQueryRepository.getAllLetterListForMentor(user, pageNumber);
+  }
+
+  /**
+   * 미응답(답장이 없는) 편지 목록을 조회하는 기능 (페이징 지원)
+   * 1. 사용자의 정보를 받아서 해당 사용자가 보낸 미응답 편지 목록을 조회
+   * 2. 페이징 처리 후 결과 반환
+   *
+   * @param user       조회할 사용자 (멘토 또는 멘티)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 미응답 편지 리스트 (페이지네이션 적용)
+   */
+  public PageResponse<ReceiveLetterDTO> getPendingLetterList(UserEntity user, int pageNumber) {
+    return letterQueryRepository.getPendingLetterList(user, pageNumber);
   }
 }

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -7,9 +7,11 @@ import com.enf.service.LetterService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -23,9 +25,9 @@ public class LetterController {
   /**
    * 편지 전송 API
    *
-   * @param request    HTTP 요청 객체
+   * @param request    HTTP 요청 객체 (사용자 인증 정보 포함)
    * @param sendLetter 편지 전송 요청 DTO
-   * @return 전송 결과 응답
+   * @return 전송 결과 응답 (성공/실패 여부 포함)
    */
   @PostMapping("/send")
   public ResponseEntity<ResultResponse> sendLetter(
@@ -36,12 +38,49 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 편지 답장 API
+   *
+   * @param request HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param reply   답장 요청 DTO
+   * @return 답장 결과 응답 (성공/실패 여부 포함)
+   */
   @PostMapping("/reply")
   public ResponseEntity<ResultResponse> replyLetter(
       HttpServletRequest request,
       @RequestBody ReplyLetterDTO reply) {
 
     ResultResponse response = letterService.replyLetter(request, reply);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 편지 목록 조회 API
+   *
+   * @param request    HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param pageNumber 조회할 페이지 번호
+   * @return 편지 목록 응답 (페이징된 데이터 포함)
+   */
+  @GetMapping("/list/all")
+  public ResponseEntity<ResultResponse> getAllLetterList(HttpServletRequest request,
+      @RequestParam(name = "pageNumber") int pageNumber) {
+
+    ResultResponse response = letterService.getAllLetterList(request, pageNumber);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 답장이 없는 미응답 편지 목록 조회 API
+   *
+   * @param request    HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param pageNumber 조회할 페이지 번호
+   * @return 미응답 편지 목록 응답 (페이징된 데이터 포함)
+   */
+  @GetMapping("/list/pending")
+  public ResponseEntity<ResultResponse> getPendingLetterList(HttpServletRequest request,
+      @RequestParam(name = "pageNumber") int pageNumber) {
+
+    ResultResponse response = letterService.getPendingLetterList(request, pageNumber);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterEntity.java
@@ -23,14 +23,6 @@ public class LetterEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long letterSeq;
 
-  @ManyToOne
-  @JoinColumn(name = "mentee_seq")
-  private UserEntity mentee;
-
-  @ManyToOne
-  @JoinColumn(name = "mentor_seq")
-  private UserEntity mentor;
-
   private String categoryName;
 
   private String letterTitle;
@@ -38,8 +30,4 @@ public class LetterEntity {
   private String letter;
 
   private LocalDateTime createAt;
-
-  @ManyToOne
-  @JoinColumn(name = "reply_to")
-  private LetterEntity replyTo;
 }

--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -1,0 +1,43 @@
+package com.enf.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "letter_status")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class LetterStatusEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long letterStatusSeq;
+
+  @ManyToOne
+  @JoinColumn(name = "mentee_seq")
+  private UserEntity mentee;
+
+  @ManyToOne
+  @JoinColumn(name = "mentor_seq")
+  private UserEntity mentor;
+
+  @ManyToOne
+  @JoinColumn(name = "mentee_letter_seq")
+  private LetterEntity menteeLetter;
+
+  @ManyToOne
+  @JoinColumn(name = "mentor_letter_seq")
+  private LetterEntity mentorLetter;
+
+  private LocalDateTime createAt;
+}

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
@@ -34,17 +34,13 @@ public class ReplyLetterDTO {
     this.letter = letter;
   }
 
-  public static LetterEntity of(UserEntity mentor, UserEntity mentee, ReplyLetterDTO replyLetter,
-      LetterEntity menteeLetter) {
+  public static LetterEntity of(ReplyLetterDTO replyLetter) {
 
     return LetterEntity.builder()
-        .mentor(mentor)
-        .mentee(mentee)
         .categoryName(replyLetter.getCategoryName())
         .letterTitle(replyLetter.getTitle())
         .letter(replyLetter.getLetter())
         .createAt(LocalDateTime.now())
-        .replyTo(menteeLetter)
         .build();
   }
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
@@ -31,10 +31,8 @@ public class SendLetterDTO {
   }
 
 
-  public static LetterEntity of(UserEntity mentee, UserEntity mentor, SendLetterDTO sendLetter) {
+  public static LetterEntity of(SendLetterDTO sendLetter) {
     return LetterEntity.builder()
-        .mentee(mentee)
-        .mentor(mentor)
         .categoryName(sendLetter.getCategoryName())
         .letterTitle(sendLetter.getTitle())
         .letter(sendLetter.getLetter())

--- a/EnF/src/main/java/com/enf/model/dto/response/PageResponse.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/PageResponse.java
@@ -1,0 +1,52 @@
+package com.enf.model.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+
+  private int pageNumber;  // 현재 페이지 번호
+  private int totalPage;   // 총 페이지 수
+  private Long totalData;  // 전체 데이터 개수
+  private List<T> dataList; // 현재 페이지의 데이터 리스트
+
+  /**
+   * 리스트 데이터를 페이징 처리하여 PageResponse로 변환
+   *
+   * @param list       페이징할 리스트 데이터
+   * @param pageNumber 요청한 페이지 번호
+   * @return PageResponse 형태의 페이징 결과
+   */
+  public static <T> PageResponse<T> pagination(List<T> list, int pageNumber) {
+    int pageSize = 8;  // 페이지 크기 설정
+    Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
+    int start = (int) pageable.getOffset();
+
+    // start 인덱스가 데이터 리스트 크기를 초과하면 빈 페이지 반환
+    if (start >= list.size()) {
+      return new PageResponse<>(pageNumber, 0, 0L, List.of());
+    }
+
+    int end = Math.min(start + pageSize, list.size());
+    List<T> pagedList = list.subList(start, end);
+
+    // 페이징 객체 생성
+    Page<T> page = new PageImpl<>(pagedList, pageable, list.size());
+
+    // PageResponse 변환 및 반환
+    return new PageResponse<>(
+        page.getNumber() + 1,   // 페이지 번호는 1부터 시작
+        page.getTotalPages(),   // 전체 페이지 수
+        page.getTotalElements(),// 전체 데이터 개수
+        page.getContent()       // 현재 페이지 데이터 리스트
+    );
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
@@ -1,0 +1,24 @@
+package com.enf.model.dto.response.letter;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReceiveLetterDTO {
+
+  private Long letterSeq;
+
+  private String birdName;
+
+  private String nickname;
+
+  private String title;
+
+//  private boolean read;
+//
+//  private boolean saved;
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -16,7 +16,9 @@ public enum SuccessResultType {
   SUCCESS_UPDATE_NICKNAME(HttpStatus.OK, "닉네임 수정 성공"),
   SUCCESS_UPDATE_CATEGORY(HttpStatus.OK, "카테고리 수정 성공"),
   SUCCESS_SEND_LETTER(HttpStatus.OK, "편지 전송 성공"),
-  SUCCESS_RECEIVE_LETTER(HttpStatus.OK, "편지 답장 성공")
+  SUCCESS_RECEIVE_LETTER(HttpStatus.OK, "편지 답장 성공"),
+  SUCCESS_GET_ALL_LETTER(HttpStatus.OK, "모든 편지 조회 성공"),
+  SUCCESS_GET_PENDING_LETTER(HttpStatus.OK, "담장을 기다리는 편지 조회 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterRepository.java
@@ -1,6 +1,8 @@
 package com.enf.repository;
 
 import com.enf.entity.LetterEntity;
+import com.enf.entity.UserEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -1,0 +1,24 @@
+package com.enf.repository;
+
+import com.enf.entity.LetterEntity;
+import com.enf.entity.LetterStatusEntity;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity, Long> {
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.mentorLetter = :mentorLetter, ls.createAt = CURRENT_TIMESTAMP "
+      + "WHERE ls.menteeLetter = :menteeLetter")
+  void updateLetterStatus(
+      @Param("mentorLetter") LetterEntity mentorLetter,
+      @Param("menteeLetter") LetterEntity menteeLetter
+  );
+}

--- a/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
@@ -1,0 +1,149 @@
+package com.enf.repository.querydsl;
+
+import com.enf.entity.LetterStatusEntity;
+import com.enf.entity.QLetterStatusEntity;
+import com.enf.entity.UserEntity;
+import com.enf.model.dto.response.PageResponse;
+import com.enf.model.dto.response.letter.ReceiveLetterDTO;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+/**
+ * LetterQueryRepository
+ *
+ * 편지의 상태 정보를 조회하는 QueryDSL 기반의 JPA 레포지토리 클래스.
+ * 멘티와 멘토가 받은 편지를 조회하는 기능을 담당하며, 페이징 처리 기능을 포함한다.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class LetterQueryRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  QLetterStatusEntity letterStatus = QLetterStatusEntity.letterStatusEntity;
+
+  /**
+   * 멘티가 보낸 편지 목록 조회 (페이징 지원)
+   *
+   * 1. 특정 멘티가 보낸 편지 목록을 가져온다.
+   * 2. mentorLetter(멘토가 보낸 답장)가 null이면, 아직 답장이 없는 편지로 간주한다.
+   * 3. mentorLetter가 존재하면, 해당 편지는 답장이 완료된 것으로 간주한다.
+   * 4. 받은 데이터를 PageResponse 형태로 변환하여 반환한다.
+   *
+   * @param mentee     현재 로그인한 멘티 사용자
+   * @param pageNumber 요청한 페이지 번호
+   * @return 멘티가 보낸 편지 리스트 (페이지네이션 적용)
+   */
+  public PageResponse<ReceiveLetterDTO> getAllLetterListForMenTee(UserEntity mentee, int pageNumber) {
+
+    // 멘티가 보낸 모든 편지 상태 조회
+    List<LetterStatusEntity> letterStatusList = jpaQueryFactory
+        .selectFrom(letterStatus)
+        .where(letterStatus.mentee.eq(mentee))  // 특정 멘티가 보낸 편지만 조회
+        .orderBy(letterStatus.createAt.desc())  // 날짜 순 정렬
+        .fetch();
+
+    // 편지 상태 데이터를 ReceiveLetterDTO로 변환
+    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
+        .map(letterStatus -> {
+          if (letterStatus.getMentorLetter() == null) {
+            // 답장이 없는 편지일 경우 익명 정보로 반환
+            return new ReceiveLetterDTO(
+                letterStatus.getMenteeLetter().getLetterSeq(),
+                "익명새",
+                "익명새",
+                letterStatus.getMenteeLetter().getLetterTitle()
+            );
+          } else {
+            // 답장이 있는 편지일 경우 멘토 정보를 포함하여 반환
+            return new ReceiveLetterDTO(
+                letterStatus.getMentorLetter().getLetterSeq(),
+                letterStatus.getMentor().getBird().getBirdName(),
+                letterStatus.getMentor().getNickname(),
+                letterStatus.getMentorLetter().getLetterTitle()
+            );
+          }
+        })
+        .toList();
+
+    // 페이징 처리 후 반환
+    return PageResponse.pagination(receiveLetters, pageNumber);
+  }
+
+  /**
+   * 멘토가 받은 편지 목록 조회 (페이징 지원)
+   *
+   * 1. 특정 멘토가 받은 편지 목록을 가져온다.
+   * 2. 받은 편지는 menteeLetter로 구분되며, 답장을 보냈는지 여부는 별도 로직에서 확인 가능하다.
+   * 3. 받은 데이터를 PageResponse 형태로 변환하여 반환한다.
+   *
+   * @param mentor     현재 로그인한 멘토 사용자
+   * @param pageNumber 요청한 페이지 번호
+   * @return 멘토가 받은 편지 리스트 (페이지네이션 적용)
+   */
+  public PageResponse<ReceiveLetterDTO> getAllLetterListForMentor(UserEntity mentor, int pageNumber) {
+
+    // 멘토가 받은 모든 편지 상태 조회
+    List<LetterStatusEntity> letterStatusList = jpaQueryFactory
+        .selectFrom(letterStatus)
+        .where(letterStatus.mentor.eq(mentor))  // 특정 멘토가 받은 편지만 조회
+        .orderBy(letterStatus.createAt.desc())   // 날짜 순 정렬
+        .fetch();
+
+    // 편지 상태 데이터를 ReceiveLetterDTO로 변환
+    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
+        .map(letterStatus ->
+            new ReceiveLetterDTO(
+                letterStatus.getMenteeLetter().getLetterSeq(),
+                letterStatus.getMentee().getBird().getBirdName(),
+                letterStatus.getMentee().getNickname(),
+                letterStatus.getMenteeLetter().getLetterTitle()
+            )
+        )
+        .toList();
+
+    // 페이징 처리 후 반환
+    return PageResponse.pagination(receiveLetters, pageNumber);
+  }
+
+  /**
+   * 미응답(멘토가 아직 답장하지 않은) 편지 목록을 조회하는 기능 (페이징 지원)
+   * 1. 특정 멘티가 보낸 편지 중에서 아직 멘토가 답장하지 않은 편지를 조회
+   * 2. 최신순으로 정렬하여 가져옴
+   * 3. 조회된 데이터를 DTO로 변환하여 리스트로 생성
+   * 4. 페이징 처리 후 결과 반환
+   *
+   * @param mentee     조회할 멘티 (편지를 보낸 사용자)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 미응답 편지 리스트 (페이지네이션 적용)
+   */
+  public PageResponse<ReceiveLetterDTO> getPendingLetterList(UserEntity mentee, int pageNumber) {
+    // 멘토가 아직 답장하지 않은 편지 상태 조회
+    List<LetterStatusEntity> letterStatusList = jpaQueryFactory
+        .selectFrom(letterStatus)
+        .where(
+            letterStatus.mentee.eq(mentee), // 특정 멘티가 보낸 편지
+            letterStatus.mentorLetter.isNull() // 답장이 없는 상태만 조회
+        )
+        .orderBy(letterStatus.createAt.desc()) // 최신순 정렬
+        .fetch();
+
+    // 조회된 편지 상태 데이터를 ReceiveLetterDTO로 변환
+    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
+        .map(letterStatus ->
+            new ReceiveLetterDTO(
+                letterStatus.getMenteeLetter().getLetterSeq(),
+                "익명새", // 답장이 없으므로 익명으로 표시
+                "익명새",
+                letterStatus.getMenteeLetter().getLetterTitle()
+            )
+        )
+        .toList();
+
+    // 페이징 처리 후 반환
+    return PageResponse.pagination(receiveLetters, pageNumber);
+  }
+}

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -10,4 +10,8 @@ public interface LetterService {
   ResultResponse sendLetter(HttpServletRequest request, SendLetterDTO sendLetter);
 
   ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter);
+
+  ResultResponse getAllLetterList(HttpServletRequest request, int pageNumber);
+
+  ResultResponse getPendingLetterList(HttpServletRequest request, int pageNumber);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -7,7 +7,9 @@ import com.enf.entity.UserEntity;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.notification.NotificationDTO;
+import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.type.SuccessResultType;
 import com.enf.model.type.TokenType;
 import com.enf.service.LetterService;
@@ -17,10 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-/**
- * 편지 서비스 구현체
- * 사용자가 편지를 작성하고 상대방에게 전송하는 기능을 담당
- */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,10 +30,10 @@ public class LetterServiceImpl implements LetterService {
   private final RedisTemplate<String, Object> redisTemplate;
 
   /**
-   * 사용자가 편지를 작성하고 상대방에게 전송하는 기능
-   * 1. 요청자의 정보를 조회하여 보낸 사용자 식별
-   * 2. 수신자의 정보를 조회
-   * 3. 편지 정보를 저장
+   * 사용자가 새로운 편지를 작성하여 상대방에게 전송하는 기능
+   * 1. 요청자의 정보를 조회하여 보낸 사용자(멘티) 식별
+   * 2. 수신자의 정보를 조회 (멘토)
+   * 3. 편지 정보를 저장 (멘티가 보낸 편지 저장)
    * 4. Redis Pub/Sub을 이용해 알림 전송
    *
    * @param request    HTTP 요청 객체 (토큰 확인)
@@ -46,23 +45,23 @@ public class LetterServiceImpl implements LetterService {
     UserEntity mentee = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
     UserEntity mentor = userFacade.getMentorByBirdAndCategory(sendLetter);
 
-    letterFacade.saveLetter(SendLetterDTO.of(mentee, mentor, sendLetter));
+    letterFacade.saveMenteeLetter(SendLetterDTO.of(sendLetter), mentee, mentor);
     redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(mentee, mentor));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_SEND_LETTER);
   }
 
-
   /**
-   * 사용자가 편지를 확인하고 상대방에게 답장하는 기능
-   * 1. 요청자의 정보를 조회하여 보낸 사용자 식별
-   * 2. 수신자의 정보를 조회
-   * 3. 편지 정보를 저장
-   * 4. Redis Pub/Sub을 이용해 알림 전송
+   * 사용자가 받은 편지에 대해 답장을 작성하는 기능
+   * 1. 요청자의 정보를 조회하여 보낸 사용자(멘토) 식별
+   * 2. 수신자의 정보를 조회 (멘티)
+   * 3. 원본 편지를 조회 (멘티가 보낸 편지)
+   * 4. 답장 정보를 저장 (멘토 -> 멘티)
+   * 5. Redis Pub/Sub을 이용해 알림 전송
    *
-   * @param request    HTTP 요청 객체 (토큰 확인)
+   * @param request     HTTP 요청 객체 (토큰 확인)
    * @param replyLetter 답장을 위해 사용자가 작성한 편지 정보
-   * @return 편지 전송 결과 응답 객체
+   * @return 답장 전송 결과 응답 객체
    */
   @Override
   public ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter) {
@@ -71,9 +70,46 @@ public class LetterServiceImpl implements LetterService {
 
     LetterEntity menteeLetter = letterFacade.findLetterByLetterSeq(replyLetter.getLetterSeq());
 
-    letterFacade.saveLetter(ReplyLetterDTO.of(mentor, mentee, replyLetter, menteeLetter));
+    letterFacade.saveMentorLetter(ReplyLetterDTO.of(replyLetter), menteeLetter);
     redisTemplate.convertAndSend("notifications", NotificationDTO.replyLetter(mentor, mentee));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_RECEIVE_LETTER);
+  }
+
+  /**
+   * 사용자가 받은 모든 편지를 조회하는 기능 (페이징 지원)
+   *
+   * @param request    HTTP 요청 객체 (토큰 확인)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 받은 편지 리스트 (페이지네이션 적용)
+   */
+  @Override
+  public ResultResponse getAllLetterList(HttpServletRequest request, int pageNumber) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    PageResponse<ReceiveLetterDTO> letters = letterFacade.getAllLetterList(user, pageNumber);
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_ALL_LETTER, letters);
+  }
+
+  /**
+   * 답장이 없는 미응답 편지 목록을 조회하는 기능 (페이징 지원)
+   * 1. 요청자의 정보를 조회하여 사용자 식별
+   * 2. 미응답 편지 리스트 조회
+   * 3. 페이징 처리 후 결과 반환
+   *
+   * @param request    HTTP 요청 객체 (토큰 확인)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 미응답 편지 리스트 (페이지네이션 적용)
+   */
+  @Override
+  public ResultResponse getPendingLetterList(HttpServletRequest request, int pageNumber) {
+    // 사용자 정보 조회
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    // 미응답 편지 리스트 조회 및 페이징 처리
+    PageResponse<ReceiveLetterDTO> letters = letterFacade.getPendingLetterList(user, pageNumber);
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_PENDING_LETTER, letters);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
#### LetterEntity.java
   - mentee, mentor 필드 삭제 (→ LetterStatusEntity에서 관리).
   - replyTo 필드 제거 (멘토 답장 관리는 LetterStatusEntity에서 처리).

#### LetterStatusEntity.java (신규)
   - 편지 상태 관리 전용 엔티티 추가.
   - mentee, mentor, menteeLetter, mentorLetter 필드 포함.
   - createAt 필드 추가.

#### LetterFacade.java
   - saveMenteeLetter: 멘티가 보낸 편지 저장 시 LetterStatusEntity도 저장하도록 변경.
   - saveMentorLetter: 멘토가 답장 시 LetterStatusEntity 업데이트 로직 추가.
   - getAllLetterList, getPendingLetterList: 페이징 기능 추가.

#### LetterController.java
   - GET /list/all: 모든 편지 조회 API 추가.
   - GET /list/pending: 미응답 편지 조회 API 추가.

#### LetterServiceImpl.java
   - sendLetter: saveMenteeLetter 호출로 변경.
   - replyLetter: saveMentorLetter 호출로 변경.
   - getAllLetterList: 페이징 지원 추가.
   - getPendingLetterList: 미응답 편지 조회 및 페이징 지원 추가.

#### LetterQueryRepository.java
   - getAllLetterListForMenTee: 멘티가 보낸 편지 조회.
   - getAllLetterListForMentor: 멘토가 받은 편지 조회.
   - getPendingLetterList: 미응답(답장이 없는) 편지 조회.

#### LetterStatusRepository.java
   - updateLetterStatus: 멘토의 답장 저장 시 mentorLetter 및 createAt 업데이트.

#### PageResponse.java
   - 페이징 처리 메서드 추가.
   - 데이터가 없을 경우 빈 리스트 반환.

#### SuccessResultType.java
   - SUCCESS_GET_ALL_LETTER, SUCCESS_GET_PENDING_LETTER 상태 추가.

## 스크린샷

## 주의사항

Closes #38 
