### PR TITLE
[feat] 편지 저장, 저장한 편지 조회, 편지 상세정보 조회 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -6,6 +6,7 @@ import com.enf.entity.NotificationEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.response.PageResponse;
+import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
@@ -146,5 +147,27 @@ public class LetterFacade {
     } else {
       letterStatusRepository.saveLetterForMentor(letterSeq);
     }
+  }
+
+  /**
+   * 편지 상세 정보 조회 메서드
+   *
+   * 1. 요청한 편지 ID(letterSeq)에 해당하는 편지 상태 정보를 조회
+   * 2. 해당 편지가 존재하지 않으면 예외 발생 (LETTER_NOT_FOUND)
+   * 3. 사용자의 역할(멘티/멘토)에 따라 다른 DTO 변환 로직 수행
+   *
+   * @param user      요청한 사용자 (멘티 또는 멘토)
+   * @param letterSeq 조회할 편지의 고유 식별자 (ID)
+   * @return 편지 상세 정보를 포함하는 LetterDetailsDTO
+   * @throws GlobalException 편지를 찾을 수 없는 경우 LETTER_NOT_FOUND 예외 발생
+   */
+  public LetterDetailsDTO getLetterDetails(UserEntity user, Long letterSeq) {
+    LetterStatusEntity letterStatus = letterStatusRepository
+        .findLetterStatusByLetterStatusSeq(letterSeq)
+        .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
+
+    return user.getRole().getRoleName().equals("MENTEE")
+        ? LetterDetailsDTO.ofMentee(letterStatus)
+        : LetterDetailsDTO.ofMentor(letterStatus);
   }
 }

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -166,6 +166,18 @@ public class LetterFacade {
         .findLetterStatusByLetterStatusSeq(letterSeq)
         .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
 
+    boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
+
+    if (isMentee) {
+      if (!letterStatus.isMenteeRead()) {
+        letterStatusRepository.updateIsMenteeRead(letterSeq);
+      }
+    } else {
+      if (!letterStatus.isMentorRead()) {
+        letterStatusRepository.updateIsMentorRead(letterSeq);
+      }
+    }
+
     return user.getRole().getRoleName().equals("MENTEE")
         ? LetterDetailsDTO.ofMentee(letterStatus)
         : LetterDetailsDTO.ofMentor(letterStatus);

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -6,7 +6,6 @@ import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.LetterService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -84,6 +84,13 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 저장된 편지 목록 조회 API
+   *
+   * @param request    HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param pageNumber 조회할 페이지 번호
+   * @return 저장된 편지 목록 응답 (페이징된 데이터 포함)
+   */
   @GetMapping("/list/save")
   public ResponseEntity<ResultResponse> getSaveLetterList(HttpServletRequest request,
       @RequestParam(name = "pageNumber") int pageNumber) {
@@ -92,11 +99,33 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
-  @GetMapping("save")
+  /**
+   * 특정 편지를 저장하는 API (멘티, 멘토 공통)
+   *
+   * @param request   HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param letterSeq 저장할 편지의 고유 식별자 (ID)
+   * @return 저장 결과 응답 (성공/실패 여부 포함)
+   */
+  @GetMapping("/save")
   public ResponseEntity<ResultResponse> saveLetter(HttpServletRequest request,
       @RequestParam(name = "letterSeq") Long letterSeq) {
 
     ResultResponse response = letterService.saveLetter(request, letterSeq);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 편지 상세 조회 API
+   *
+   * @param request   HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param letterSeq 조회할 편지의 고유 식별자 (ID)
+   * @return 편지 상세 정보 응답 (성공/실패 여부 포함)
+   */
+  @GetMapping("/details")
+  public ResponseEntity<ResultResponse> getLetterDetails(HttpServletRequest request,
+      @RequestParam(name = "letterSeq") Long letterSeq) {
+
+    ResultResponse response = letterService.getLetterDetails(request, letterSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -6,6 +6,7 @@ import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.LetterService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,6 +82,22 @@ public class LetterController {
       @RequestParam(name = "pageNumber") int pageNumber) {
 
     ResultResponse response = letterService.getPendingLetterList(request, pageNumber);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/list/save")
+  public ResponseEntity<ResultResponse> getSaveLetterList(HttpServletRequest request,
+      @RequestParam(name = "pageNumber") int pageNumber) {
+
+    ResultResponse response = letterService.getSaveLetterList(request, pageNumber);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("save")
+  public ResponseEntity<ResultResponse> saveLetter(HttpServletRequest request,
+      @RequestParam(name = "letterSeq") Long letterSeq) {
+
+    ResultResponse response = letterService.saveLetter(request, letterSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterEntity.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -1,5 +1,6 @@
 package com.enf.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,6 +39,18 @@ public class LetterStatusEntity {
   @ManyToOne
   @JoinColumn(name = "mentor_letter_seq")
   private LetterEntity mentorLetter;
+
+  @Column(name = "is_mentee_read")
+  private boolean isMenteeRead;
+
+  @Column(name = "is_mentor_read")
+  private boolean isMentorRead;
+
+  @Column(name = "is_mentee_saved")
+  private boolean isMenteeSaved;
+
+  @Column(name = "is_mentor_saved")
+  private boolean isMentorSaved;
 
   private LocalDateTime createAt;
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
@@ -1,7 +1,6 @@
 package com.enf.model.dto.request.letter;
 
 import com.enf.entity.LetterEntity;
-import com.enf.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
@@ -1,7 +1,6 @@
 package com.enf.model.dto.request.letter;
 
 import com.enf.entity.LetterEntity;
-import com.enf.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDTO.java
@@ -1,0 +1,47 @@
+package com.enf.model.dto.response.letter;
+
+import com.enf.entity.LetterEntity;
+import com.enf.entity.UserEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LetterDTO {
+
+  private Long letterSeq;
+
+  private String replyUserBird;
+
+  private String replyUser;
+
+  private String letterTitle;
+
+  private String categoryName;
+
+  private String letter;
+
+  private LocalDateTime creatAt;
+
+  private String sendUserBird;
+
+  private String sendUser;
+
+  public static LetterDTO of(UserEntity replyUser, UserEntity sendUser, LetterEntity letter) {
+
+    return new LetterDTO(
+        letter.getLetterSeq(),
+        replyUser == null ? "익명새" : replyUser.getBird().getBirdName(),
+        replyUser == null ? "익명새" : replyUser.getNickname(),
+        letter.getLetterTitle(),
+        letter.getCategoryName(),
+        letter.getLetter(),
+        letter.getCreateAt(),
+        sendUser.getBird().getBirdName(),
+        sendUser.getNickname()
+    );
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
@@ -1,0 +1,52 @@
+package com.enf.model.dto.response.letter;
+
+import com.enf.entity.LetterStatusEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LetterDetailsDTO {
+
+  private LetterDTO replyLetter;
+
+  private LetterDTO sendLetter;
+
+  public static LetterDetailsDTO ofMentee(LetterStatusEntity letterStatus) {
+
+    LetterDTO replyLetter = letterStatus.getMentorLetter() == null
+        ? null
+        : LetterDTO.of(
+        letterStatus.getMentor(),
+        letterStatus.getMentor(),
+        letterStatus.getMentorLetter()
+    );
+
+        LetterDTO sendLetter = LetterDTO.of(
+        null,
+        letterStatus.getMentee(),
+        letterStatus.getMenteeLetter()
+    );
+
+    return new LetterDetailsDTO(replyLetter, sendLetter);
+  }
+
+  public static LetterDetailsDTO ofMentor(LetterStatusEntity letterStatus) {
+
+    LetterDTO replyLetter = LetterDTO.of(
+        letterStatus.getMentee(),
+        letterStatus.getMentor(),
+        letterStatus.getMenteeLetter()
+    );
+
+    LetterDTO sendLetter = LetterDTO.of(
+        letterStatus.getMentor(),
+        letterStatus.getMentee(),
+        letterStatus.getMentorLetter()
+    );
+
+    return new LetterDetailsDTO(replyLetter, sendLetter);
+  }
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
@@ -1,6 +1,7 @@
 package com.enf.model.dto.response.letter;
 
-import java.time.LocalDateTime;
+import com.enf.entity.LetterStatusEntity;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +19,42 @@ public class ReceiveLetterDTO {
 
   private String title;
 
-//  private boolean read;
-//
-//  private boolean saved;
+  private boolean read;
+
+  private boolean saved;
+
+
+  public static List<ReceiveLetterDTO> ofMentee(List<LetterStatusEntity> list) {
+    return list.stream()
+        .map(letterStatus -> {
+          boolean isPending = letterStatus.getMentorLetter() == null;
+          return new ReceiveLetterDTO(
+              letterStatus.getLetterStatusSeq(),
+              isPending ? "익명새" : letterStatus.getMentor().getBird().getBirdName(),
+              isPending ? "익명새" : letterStatus.getMentor().getNickname(),
+              isPending
+                  ? letterStatus.getMenteeLetter().getLetterTitle()
+                  : letterStatus.getMentorLetter().getLetterTitle(),
+              letterStatus.isMenteeRead(),
+              letterStatus.isMenteeSaved()
+          );
+        })
+        .toList();
+  }
+
+  public static List<ReceiveLetterDTO> ofMentor(List<LetterStatusEntity> list) {
+    return list.stream()
+        .map(letterStatus ->
+            new ReceiveLetterDTO(
+                letterStatus.getLetterStatusSeq(),
+                letterStatus.getMentee().getBird().getBirdName(),
+                letterStatus.getMentee().getNickname(),
+                letterStatus.getMenteeLetter().getLetterTitle(),
+                letterStatus.isMentorRead(),
+                letterStatus.isMentorSaved()
+            )
+        )
+        .toList();
+  }
+
 }

--- a/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/user/UserInfoDTO.java
@@ -25,7 +25,7 @@ public class UserInfoDTO {
         user.getBird().getBirdName(),
         user.getNickname(),
         user.getRole().getRoleName(),
-        user.getRole().getRoleName().equals("senior")
+        user.getRole().getRoleName().equals("MENTOR")
             ? UserCategoryDTO.of(user.getCategory())
             : null);
 

--- a/EnF/src/main/java/com/enf/model/type/LetterListType.java
+++ b/EnF/src/main/java/com/enf/model/type/LetterListType.java
@@ -1,0 +1,14 @@
+package com.enf.model.type;
+
+import lombok.Getter;
+
+@Getter
+public enum LetterListType {
+  ALL("all"), PENDING("pending"), SAVE("save");
+
+  private final String value;
+
+  LetterListType(String value) {
+    this.value = value;
+  }
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -21,6 +21,7 @@ public enum SuccessResultType {
   SUCCESS_GET_PENDING_LETTER(HttpStatus.OK, "담장을 기다리는 편지 조회 성공"),
   SUCCESS_GET_SAVE_LETTER(HttpStatus.OK, "저장한 편지 조회 성공"),
   SUCCESS_SAVE_LETTER(HttpStatus.OK, "편지 저장 성공"),
+  SUCCESS_GET_LETTER_DETAILS(HttpStatus.OK, "편지 상세 조회 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -19,6 +19,8 @@ public enum SuccessResultType {
   SUCCESS_RECEIVE_LETTER(HttpStatus.OK, "편지 답장 성공"),
   SUCCESS_GET_ALL_LETTER(HttpStatus.OK, "모든 편지 조회 성공"),
   SUCCESS_GET_PENDING_LETTER(HttpStatus.OK, "담장을 기다리는 편지 조회 성공"),
+  SUCCESS_GET_SAVE_LETTER(HttpStatus.OK, "저장한 편지 조회 성공"),
+  SUCCESS_SAVE_LETTER(HttpStatus.OK, "편지 저장 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterRepository.java
@@ -1,8 +1,6 @@
 package com.enf.repository;
 
 import com.enf.entity.LetterEntity;
-import com.enf.entity.UserEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -3,6 +3,7 @@ package com.enf.repository;
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -33,4 +34,6 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
   @Query("UPDATE letter_status ls "
       + "SET ls.isMentorSaved = true WHERE ls.letterStatusSeq = :letterSeq")
   void saveLetterForMentor(@Param("letterSeq") Long letterSeq);
+
+  Optional<LetterStatusEntity> findLetterStatusByLetterStatusSeq(Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -36,4 +36,16 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
   void saveLetterForMentor(@Param("letterSeq") Long letterSeq);
 
   Optional<LetterStatusEntity> findLetterStatusByLetterStatusSeq(Long letterSeq);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.isMenteeRead = true WHERE ls.letterStatusSeq = :letterSeq")
+  void updateIsMenteeRead(@Param("letterSeq") Long letterSeq);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.isMentorRead = true WHERE ls.letterStatusSeq = :letterSeq")
+  void updateIsMentorRead(@Param("letterSeq") Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -21,4 +21,16 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
       @Param("mentorLetter") LetterEntity mentorLetter,
       @Param("menteeLetter") LetterEntity menteeLetter
   );
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.isMenteeSaved = true WHERE ls.letterStatusSeq = :letterSeq")
+  void saveLetterForMentee(@Param("letterSeq") Long letterSeq);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.isMentorSaved = true WHERE ls.letterStatusSeq = :letterSeq")
+  void saveLetterForMentor(@Param("letterSeq") Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
@@ -5,7 +5,6 @@ import com.enf.entity.QLetterStatusEntity;
 import com.enf.entity.UserEntity;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
-import com.enf.model.type.LetterListType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;

--- a/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
@@ -5,18 +5,15 @@ import com.enf.entity.QLetterStatusEntity;
 import com.enf.entity.UserEntity;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
+import com.enf.model.type.LetterListType;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
-/**
- * LetterQueryRepository
- *
- * 편지의 상태 정보를 조회하는 QueryDSL 기반의 JPA 레포지토리 클래스.
- * 멘티와 멘토가 받은 편지를 조회하는 기능을 담당하며, 페이징 처리 기능을 포함한다.
- */
+
 @Slf4j
 @Repository
 @RequiredArgsConstructor
@@ -26,124 +23,54 @@ public class LetterQueryRepository {
   QLetterStatusEntity letterStatus = QLetterStatusEntity.letterStatusEntity;
 
   /**
-   * 멘티가 보낸 편지 목록 조회 (페이징 지원)
+   * 멘티 또는 멘토의 편지 목록 조회 (페이징 지원)
    *
-   * 1. 특정 멘티가 보낸 편지 목록을 가져온다.
-   * 2. mentorLetter(멘토가 보낸 답장)가 null이면, 아직 답장이 없는 편지로 간주한다.
-   * 3. mentorLetter가 존재하면, 해당 편지는 답장이 완료된 것으로 간주한다.
-   * 4. 받은 데이터를 PageResponse 형태로 변환하여 반환한다.
+   * 1. 사용자 역할(멘티 또는 멘토)에 따라 적절한 필터링을 수행한다.
+   * 2. `letterListType` 파라미터를 기반으로 추가적인 조건을 적용한다.
+   *    - "all"     : 모든 편지 조회
+   *    - "pending" : 답장이 없는 편지만 조회 (멘티가 보낸 편지 중 mentorLetter가 null인 경우)
+   *    - "save"    : 저장된 편지만 조회 (멘티와 멘토 각각 menteeSaved 또는 mentorSaved 필터링)
+   * 3. 조회된 데이터를 `ReceiveLetterDTO`로 변환하여 반환한다.
+   * 4. 페이징 처리 후 최종 결과를 반환한다.
    *
-   * @param mentee     현재 로그인한 멘티 사용자
-   * @param pageNumber 요청한 페이지 번호
-   * @return 멘티가 보낸 편지 리스트 (페이지네이션 적용)
+   * @param user         현재 로그인한 사용자 (멘티 또는 멘토)
+   * @param pageNumber   요청한 페이지 번호
+   * @param letterListType 조회할 편지 유형 (all, pending, save)
+   * @return 사용자 역할 및 요청 유형에 따른 편지 리스트 (페이지네이션 적용)
    */
-  public PageResponse<ReceiveLetterDTO> getAllLetterListForMenTee(UserEntity mentee, int pageNumber) {
+  public PageResponse<ReceiveLetterDTO> getLetterList(UserEntity user, int pageNumber, String letterListType) {
+    boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
+    BooleanBuilder builder = new BooleanBuilder();
 
-    // 멘티가 보낸 모든 편지 상태 조회
+    // 사용자 역할에 따라 mentee 또는 mentor 기준으로 필터링
+    builder.and(isMentee ? letterStatus.mentee.eq(user) : letterStatus.mentor.eq(user));
+
+    // letterListType에 따른 추가 필터 적용
+    switch (letterListType) {
+      case "all" :
+        break; // 모든 편지를 조회 (추가 필터 없음)
+      case "pending" :
+        builder.and(letterStatus.mentorLetter.isNull()); // 멘토가 아직 답장하지 않은 편지 조회
+        break;
+      case "save" :
+        builder.and(isMentee ? letterStatus.isMenteeSaved.isTrue() : letterStatus.isMentorSaved.isTrue()); // 저장된 편지 조회
+        break;
+    }
+
+    // 조건을 적용하여 편지 목록 조회
     List<LetterStatusEntity> letterStatusList = jpaQueryFactory
         .selectFrom(letterStatus)
-        .where(letterStatus.mentee.eq(mentee))  // 특정 멘티가 보낸 편지만 조회
-        .orderBy(letterStatus.createAt.desc())  // 날짜 순 정렬
-        .fetch();
-
-    // 편지 상태 데이터를 ReceiveLetterDTO로 변환
-    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
-        .map(letterStatus -> {
-          if (letterStatus.getMentorLetter() == null) {
-            // 답장이 없는 편지일 경우 익명 정보로 반환
-            return new ReceiveLetterDTO(
-                letterStatus.getMenteeLetter().getLetterSeq(),
-                "익명새",
-                "익명새",
-                letterStatus.getMenteeLetter().getLetterTitle()
-            );
-          } else {
-            // 답장이 있는 편지일 경우 멘토 정보를 포함하여 반환
-            return new ReceiveLetterDTO(
-                letterStatus.getMentorLetter().getLetterSeq(),
-                letterStatus.getMentor().getBird().getBirdName(),
-                letterStatus.getMentor().getNickname(),
-                letterStatus.getMentorLetter().getLetterTitle()
-            );
-          }
-        })
-        .toList();
-
-    // 페이징 처리 후 반환
-    return PageResponse.pagination(receiveLetters, pageNumber);
-  }
-
-  /**
-   * 멘토가 받은 편지 목록 조회 (페이징 지원)
-   *
-   * 1. 특정 멘토가 받은 편지 목록을 가져온다.
-   * 2. 받은 편지는 menteeLetter로 구분되며, 답장을 보냈는지 여부는 별도 로직에서 확인 가능하다.
-   * 3. 받은 데이터를 PageResponse 형태로 변환하여 반환한다.
-   *
-   * @param mentor     현재 로그인한 멘토 사용자
-   * @param pageNumber 요청한 페이지 번호
-   * @return 멘토가 받은 편지 리스트 (페이지네이션 적용)
-   */
-  public PageResponse<ReceiveLetterDTO> getAllLetterListForMentor(UserEntity mentor, int pageNumber) {
-
-    // 멘토가 받은 모든 편지 상태 조회
-    List<LetterStatusEntity> letterStatusList = jpaQueryFactory
-        .selectFrom(letterStatus)
-        .where(letterStatus.mentor.eq(mentor))  // 특정 멘토가 받은 편지만 조회
-        .orderBy(letterStatus.createAt.desc())   // 날짜 순 정렬
-        .fetch();
-
-    // 편지 상태 데이터를 ReceiveLetterDTO로 변환
-    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
-        .map(letterStatus ->
-            new ReceiveLetterDTO(
-                letterStatus.getMenteeLetter().getLetterSeq(),
-                letterStatus.getMentee().getBird().getBirdName(),
-                letterStatus.getMentee().getNickname(),
-                letterStatus.getMenteeLetter().getLetterTitle()
-            )
-        )
-        .toList();
-
-    // 페이징 처리 후 반환
-    return PageResponse.pagination(receiveLetters, pageNumber);
-  }
-
-  /**
-   * 미응답(멘토가 아직 답장하지 않은) 편지 목록을 조회하는 기능 (페이징 지원)
-   * 1. 특정 멘티가 보낸 편지 중에서 아직 멘토가 답장하지 않은 편지를 조회
-   * 2. 최신순으로 정렬하여 가져옴
-   * 3. 조회된 데이터를 DTO로 변환하여 리스트로 생성
-   * 4. 페이징 처리 후 결과 반환
-   *
-   * @param mentee     조회할 멘티 (편지를 보낸 사용자)
-   * @param pageNumber 요청한 페이지 번호
-   * @return 미응답 편지 리스트 (페이지네이션 적용)
-   */
-  public PageResponse<ReceiveLetterDTO> getPendingLetterList(UserEntity mentee, int pageNumber) {
-    // 멘토가 아직 답장하지 않은 편지 상태 조회
-    List<LetterStatusEntity> letterStatusList = jpaQueryFactory
-        .selectFrom(letterStatus)
-        .where(
-            letterStatus.mentee.eq(mentee), // 특정 멘티가 보낸 편지
-            letterStatus.mentorLetter.isNull() // 답장이 없는 상태만 조회
-        )
+        .where(builder)
         .orderBy(letterStatus.createAt.desc()) // 최신순 정렬
         .fetch();
 
-    // 조회된 편지 상태 데이터를 ReceiveLetterDTO로 변환
-    List<ReceiveLetterDTO> receiveLetters = letterStatusList.stream()
-        .map(letterStatus ->
-            new ReceiveLetterDTO(
-                letterStatus.getMenteeLetter().getLetterSeq(),
-                "익명새", // 답장이 없으므로 익명으로 표시
-                "익명새",
-                letterStatus.getMenteeLetter().getLetterTitle()
-            )
-        )
-        .toList();
+    // 사용자 역할에 따라 DTO 변환 처리
+    List<ReceiveLetterDTO> receiveLetters = isMentee
+        ? ReceiveLetterDTO.ofMentee(letterStatusList)
+        : ReceiveLetterDTO.ofMentor(letterStatusList);
 
     // 페이징 처리 후 반환
     return PageResponse.pagination(receiveLetters, pageNumber);
   }
+
 }

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -14,4 +14,8 @@ public interface LetterService {
   ResultResponse getAllLetterList(HttpServletRequest request, int pageNumber);
 
   ResultResponse getPendingLetterList(HttpServletRequest request, int pageNumber);
+
+  ResultResponse getSaveLetterList(HttpServletRequest request, int pageNumber);
+
+  ResultResponse saveLetter(HttpServletRequest request, Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -18,4 +18,6 @@ public interface LetterService {
   ResultResponse getSaveLetterList(HttpServletRequest request, int pageNumber);
 
   ResultResponse saveLetter(HttpServletRequest request, Long letterSeq);
+
+  ResultResponse getLetterDetails(HttpServletRequest request, Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -10,6 +10,7 @@ import com.enf.model.dto.request.notification.NotificationDTO;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
+import com.enf.model.type.LetterListType;
 import com.enf.model.type.SuccessResultType;
 import com.enf.model.type.TokenType;
 import com.enf.service.LetterService;
@@ -87,7 +88,8 @@ public class LetterServiceImpl implements LetterService {
   public ResultResponse getAllLetterList(HttpServletRequest request, int pageNumber) {
     UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
 
-    PageResponse<ReceiveLetterDTO> letters = letterFacade.getAllLetterList(user, pageNumber);
+    PageResponse<ReceiveLetterDTO> letters = letterFacade
+        .getLetterList(user, pageNumber, LetterListType.ALL);
 
     return new ResultResponse(SuccessResultType.SUCCESS_GET_ALL_LETTER, letters);
   }
@@ -108,8 +110,47 @@ public class LetterServiceImpl implements LetterService {
     UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
 
     // 미응답 편지 리스트 조회 및 페이징 처리
-    PageResponse<ReceiveLetterDTO> letters = letterFacade.getPendingLetterList(user, pageNumber);
+    PageResponse<ReceiveLetterDTO> letters = letterFacade
+        .getLetterList(user, pageNumber, LetterListType.PENDING);
 
     return new ResultResponse(SuccessResultType.SUCCESS_GET_PENDING_LETTER, letters);
+  }
+
+  /**
+   * 사용자가 저장한 편지 목록을 조회하는 기능 (페이징 지원)
+   * 1. 사용자 정보를 조회하여 본인의 저장된 편지 리스트를 가져온다.
+   * 2. 저장한 편지 리스트 조회.
+   * 3. 페이징 처리 후 결과 반환.
+   *
+   * @param request    HTTP 요청 객체 (토큰 확인)
+   * @param pageNumber 요청한 페이지 번호
+   * @return 저장된 편지 리스트 (페이지네이션 적용)
+   */
+  @Override
+  public ResultResponse getSaveLetterList(HttpServletRequest request, int pageNumber) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    PageResponse<ReceiveLetterDTO> letters = letterFacade.getLetterList(user, pageNumber, LetterListType.SAVE);
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_SAVE_LETTER, letters);
+  }
+
+  /**
+   * 사용자가 특정 편지를 저장하는 기능
+   * 1. 사용자 정보를 조회하여 본인을 식별
+   * 2. 특정 편지를 저장 처리
+   * 3. 저장 완료 후 성공 응답 반환
+   *
+   * @param request   HTTP 요청 객체 (토큰 확인)
+   * @param letterSeq 저장할 편지의 식별자
+   * @return 편지 저장 결과 응답 객체
+   */
+  @Override
+  public ResultResponse saveLetter(HttpServletRequest request, Long letterSeq) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    letterFacade.saveLetter(user, letterSeq);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_SAVE_LETTER);
   }
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -9,6 +9,7 @@ import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.notification.NotificationDTO;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.ResultResponse;
+import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.type.LetterListType;
 import com.enf.model.type.SuccessResultType;
@@ -152,5 +153,25 @@ public class LetterServiceImpl implements LetterService {
     letterFacade.saveLetter(user, letterSeq);
 
     return ResultResponse.of(SuccessResultType.SUCCESS_SAVE_LETTER);
+  }
+
+  /**
+   * 특정 편지의 상세 정보를 조회하는 기능
+   *
+   * 1. 요청한 사용자의 정보를 토큰을 통해 조회한다.
+   * 2. 조회된 사용자의 권한(멘티 또는 멘토)에 따라 편지 상세 정보를 가져온다.
+   * 3. 편지의 상세 내용을 조회한다.
+   * 4. 조회된 편지 상세 정보를 `ResultResponse` 객체로 감싸서 반환한다.
+   *
+   * @param request   HTTP 요청 객체 (토큰을 이용하여 사용자 인증)
+   * @param letterSeq 조회할 편지의 고유 식별자 (ID)
+   * @return 편지 상세 정보를 포함한 응답 객체
+   */
+  @Override
+  public ResultResponse getLetterDetails(HttpServletRequest request, Long letterSeq) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    LetterDetailsDTO letterDetails = letterFacade.getLetterDetails(user, letterSeq);
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_LETTER_DETAILS, letterDetails);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
### 변경사항
#### 편지 상태 관리를 위한 LetterStatusEntity 개선
   - isMenteeRead, isMentorRead, isMenteeSaved, isMentorSaved 필드 추가 → 읽음 및 저장 여부 관리 가능
   
#### LetterQueryRepository 리팩토링
   - getLetterList() 하나의 메서드로 통합 (LetterListType 활용)
   - BooleanBuilder를 이용한 QueryDSL 조건 필터링 추가
   
#### LetterFacade 리팩토링
   - getLetterList()를 통해 ALL, PENDING, SAVE 타입별 조회 가능
   - saveLetter()를 통해 멘티와 멘토의 편지 저장 로직을 분리
   
#### LetterServiceImpl 개선
   - API 요청을 LetterFacade에서 처리하도록 개선
   - getSaveLetterList(), getLetterDetails() 등 상세 로직 추가
   
#### 컨트롤러(LetterController) API 문서화 및 정리
   - @GetMapping("/details"), @GetMapping("/save") 추가
   - API 설명을 보강하여 명확한 역할 구분

##

### 클래스별 설명
#### LetterController
   - 편지 관련 API를 제공 (보내기, 답장, 목록 조회, 상세 조회, 저장 기능)
   - HTTP 요청을 처리하고 LetterService를 호출하여 결과 반환

#### LetterServiceImpl
   - LetterFacade를 활용하여 편지 관련 비즈니스 로직 처리
   - 편지 목록 조회, 답장, 저장 등의 기능 제공

#### LetterFacade 
   - 편지 저장, 상세 조회, 목록 조회 기능을 캡슐화하여 서비스 계층과 분리

#### LetterQueryRepository 
   - getLetterList()를 통해 멘티와 멘토의 편지를 한 번에 조회 가능
   - LetterListType(ALL, PENDING, SAVE)에 따라 필터링 적용

#### LetterStatusEntity 
   - 편지 상태 저장 (읽음 여부, 저장 여부 추가)
   
#### ReceiveLetterDTO, LetterDetailsDTO 
   - ReceiveLetterDTO → 받은 편지 목록을 담는 DTO
   - LetterDetailsDTO → 개별 편지 상세 정보 DTO

## 스크린샷

## 주의사항

Closes #39 
