### PR TITLE
[feat] 편지 넘기기 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -105,18 +105,6 @@ public class LetterFacade {
   }
 
   /**
-   * 특정 편지 ID로 편지 조회
-   *
-   * @param letterSeq 조회할 편지의 ID
-   * @return 조회된 LetterEntity 객체
-   * @throws GlobalException 편지가 존재하지 않을 경우 예외 발생
-   */
-  public LetterEntity findLetterByLetterSeq(Long letterSeq) {
-    return letterRepository.findByLetterSeq(letterSeq)
-        .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
-  }
-
-  /**
    * 특정 사용자의 모든 편지를 조회하는 기능 (멘티와 멘토 구분하여 처리)
    *
    * 1. 사용자 정보를 기반으로 해당 사용자가 보낸 또는 받은 편지를 조회한다.
@@ -155,6 +143,13 @@ public class LetterFacade {
     }
   }
 
+  /**
+   * 특정 편지 상태 정보를 조회
+   *
+   * @param letterStatusSeq 편지 상태 ID
+   * @return 조회된 LetterStatusEntity 객체
+   * @throws GlobalException 편지가 존재하지 않을 경우 예외 발생
+   */
   public LetterStatusEntity getLetterStatus(Long letterStatusSeq) {
     return letterStatusRepository
         .findLetterStatusByLetterStatusSeq(letterStatusSeq)
@@ -194,16 +189,22 @@ public class LetterFacade {
    * 편지를 새로운 멘토에게 전달하는 메서드
    *
    * @param letterStatus  현재 편지의 상태 정보
-   * @param newMentor     새롭게 지정될 멘토 정보
    */
-  public void throwLetter(LetterStatusEntity letterStatus, UserEntity newMentor) {
-    letterStatusRepository.updateMentor(letterStatus.getLetterStatusSeq(), newMentor);
-
+  public void throwLetter(LetterStatusEntity letterStatus) {
     ThrowLetterEntity throwLetterEntity = ThrowLetterEntity.builder()
         .letterStatus(letterStatus)
         .throwUser(letterStatus.getMentor())
         .build();
-
     throwLetterRepository.save(throwLetterEntity);
+  }
+
+  /**
+   * 편지의 멘토를 새로운 멘토로 변경
+   *
+   * @param letterStatus 현재 편지의 상태 정보
+   * @param newMentor 새로운 멘토 정보
+   */
+  public void updateMentor(LetterStatusEntity letterStatus, UserEntity newMentor) {
+    letterStatusRepository.updateMentor(letterStatus.getLetterStatusSeq(), newMentor);
   }
 }

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -3,8 +3,10 @@ package com.enf.component.facade;
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.NotificationEntity;
+import com.enf.entity.ThrowLetterEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
+import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
@@ -13,6 +15,7 @@ import com.enf.model.type.LetterListType;
 import com.enf.repository.LetterRepository;
 import com.enf.repository.LetterStatusRepository;
 import com.enf.repository.NotificationRepository;
+import com.enf.repository.ThrowLetterRepository;
 import com.enf.repository.querydsl.LetterQueryRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,6 +32,7 @@ public class LetterFacade {
   private final NotificationRepository notificationRepository;
   private final LetterStatusRepository letterStatusRepository;
   private final LetterQueryRepository letterQueryRepository;
+  private final ThrowLetterRepository throwLetterRepository;
 
   /**
    * 특정 사용자의 모든 알림 조회
@@ -87,15 +91,17 @@ public class LetterFacade {
   /**
    * 멘토가 답장을 보낼 때 편지 저장 및 상태 업데이트
    *
-   * @param letter 저장할 멘토의 답장 편지 엔티티
-   * @param menteeLetter 멘티가 보낸 원본 편지 엔티티
+   * @param letterStatus 저장할 멘토의 답장 편지 엔티티
+   * @param replyLetter 멘티가 보낸 원본 편지 엔티티
    */
-  public void saveMentorLetter(LetterEntity letter, LetterEntity menteeLetter) {
+  public void saveMentorLetter(LetterStatusEntity letterStatus, ReplyLetterDTO replyLetter) {
+    LetterEntity letter = ReplyLetterDTO
+        .of(replyLetter, letterStatus.getMenteeLetter().getCategoryName());
     // 멘토의 답장 편지를 저장
     LetterEntity mentorLetter = letterRepository.save(letter);
 
     // 기존 편지 상태 업데이트 (멘토의 답장을 반영)
-    letterStatusRepository.updateLetterStatus(mentorLetter, menteeLetter);
+    letterStatusRepository.updateLetterStatus(letterStatus.getLetterStatusSeq(), mentorLetter);
   }
 
   /**
@@ -137,49 +143,67 @@ public class LetterFacade {
    * 4. 해당 편지가 성공적으로 저장되었음을 나타내는 응답을 반환한다.
    *
    * @param user      현재 로그인한 사용자 (멘티 또는 멘토)
-   * @param letterSeq 저장할 편지의 고유 식별자 (ID)
+   * @param letterStatusSeq 저장할 편지의 고유 식별자 (ID)
    */
-  public void saveLetter(UserEntity user, Long letterSeq) {
+  public void saveLetter(UserEntity user, Long letterStatusSeq) {
     boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
 
     if (isMentee) {
-      letterStatusRepository.saveLetterForMentee(letterSeq);
+      letterStatusRepository.saveLetterForMentee(letterStatusSeq);
     } else {
-      letterStatusRepository.saveLetterForMentor(letterSeq);
+      letterStatusRepository.saveLetterForMentor(letterStatusSeq);
     }
+  }
+
+  public LetterStatusEntity getLetterStatus(Long letterStatusSeq) {
+    return letterStatusRepository
+        .findLetterStatusByLetterStatusSeq(letterStatusSeq)
+        .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
   }
 
   /**
    * 편지 상세 정보 조회 메서드
    *
-   * 1. 요청한 편지 ID(letterSeq)에 해당하는 편지 상태 정보를 조회
-   * 2. 해당 편지가 존재하지 않으면 예외 발생 (LETTER_NOT_FOUND)
-   * 3. 사용자의 역할(멘티/멘토)에 따라 다른 DTO 변환 로직 수행
+   * 사용자의 역할(멘티/멘토)에 따라 다른 DTO 변환 로직 수행
    *
    * @param user      요청한 사용자 (멘티 또는 멘토)
-   * @param letterSeq 조회할 편지의 고유 식별자 (ID)
+   * @param letterStatus 조회할 편지
    * @return 편지 상세 정보를 포함하는 LetterDetailsDTO
    * @throws GlobalException 편지를 찾을 수 없는 경우 LETTER_NOT_FOUND 예외 발생
    */
-  public LetterDetailsDTO getLetterDetails(UserEntity user, Long letterSeq) {
-    LetterStatusEntity letterStatus = letterStatusRepository
-        .findLetterStatusByLetterStatusSeq(letterSeq)
-        .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
+  public LetterDetailsDTO getLetterDetails(UserEntity user, LetterStatusEntity letterStatus) {
 
     boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
 
     if (isMentee) {
       if (!letterStatus.isMenteeRead()) {
-        letterStatusRepository.updateIsMenteeRead(letterSeq);
+        letterStatusRepository.updateIsMenteeRead(letterStatus.getLetterStatusSeq());
       }
     } else {
       if (!letterStatus.isMentorRead()) {
-        letterStatusRepository.updateIsMentorRead(letterSeq);
+        letterStatusRepository.updateIsMentorRead(letterStatus.getLetterStatusSeq());
       }
     }
 
     return user.getRole().getRoleName().equals("MENTEE")
         ? LetterDetailsDTO.ofMentee(letterStatus)
         : LetterDetailsDTO.ofMentor(letterStatus);
+  }
+
+  /**
+   * 편지를 새로운 멘토에게 전달하는 메서드
+   *
+   * @param letterStatus  현재 편지의 상태 정보
+   * @param newMentor     새롭게 지정될 멘토 정보
+   */
+  public void throwLetter(LetterStatusEntity letterStatus, UserEntity newMentor) {
+    letterStatusRepository.updateMentor(letterStatus.getLetterStatusSeq(), newMentor);
+
+    ThrowLetterEntity throwLetterEntity = ThrowLetterEntity.builder()
+        .letterStatus(letterStatus)
+        .throwUser(letterStatus.getMentor())
+        .build();
+
+    throwLetterRepository.save(throwLetterEntity);
   }
 }

--- a/EnF/src/main/java/com/enf/component/facade/UserFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/UserFacade.java
@@ -9,7 +9,6 @@ import com.enf.entity.RoleEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.auth.AuthTokenDTO;
-import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.user.UserCategoryDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.TokenType;
@@ -117,10 +116,11 @@ public class UserFacade {
   /**
    * 새 이름, 카테고리 정보와 일치하는 UserEntity 조회
    *
-   * @param sendLetter 작성한 편지 정보
+   * @param birdName 작성한 사용자의 새이름
+   * @param categoryName 작성한 편지의 카테고리
    */
-  public UserEntity getMentorByBirdAndCategory(SendLetterDTO sendLetter) {
-    return userQueryRepository.getMentor(sendLetter.getBirdName(), sendLetter.getCategoryName());
+  public UserEntity getMentorByBirdAndCategory(String birdName, String categoryName) {
+    return userQueryRepository.getMentor(birdName, categoryName);
   }
 
   public UserEntity findByNickname(String receiveUser) {

--- a/EnF/src/main/java/com/enf/component/facade/UserFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/UserFacade.java
@@ -4,6 +4,7 @@ import com.enf.component.token.HttpCookieUtil;
 import com.enf.component.token.TokenProvider;
 import com.enf.entity.BirdEntity;
 import com.enf.entity.CategoryEntity;
+import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.QuotaEntity;
 import com.enf.entity.RoleEntity;
 import com.enf.entity.UserEntity;
@@ -120,13 +121,26 @@ public class UserFacade {
    * @param categoryName 작성한 편지의 카테고리
    */
   public UserEntity getMentorByBirdAndCategory(String birdName, String categoryName) {
-    return userQueryRepository.getMentor(birdName, categoryName);
+
+    return userQueryRepository.getMentor(birdName, categoryName, null);
   }
 
-  public UserEntity findByNickname(String receiveUser) {
-    return userRepository.findByNickname(receiveUser)
-        .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
+  /**
+   * 새로운 멘토 조회 (편지를 넘긴 사용자 제외)
+   *
+   * @param letterStatus 현재 편지의 상태 정보
+   * @return 새로운 멘토 사용자 엔티티
+   */
+  public UserEntity getNewMentor(LetterStatusEntity letterStatus) {
+    String birdName = letterStatus.getMenteeLetter().getBirdName();
+    String categoryName = letterStatus.getMenteeLetter().getCategoryName();
+
+    log.info("birdName : {}", birdName);
+    log.info("categoryName : {}", categoryName);
+
+    return userQueryRepository.getMentor(birdName, categoryName, letterStatus.getLetterStatusSeq());
   }
+
 
   // ============================= Role 관련 메서드 =============================
 
@@ -226,5 +240,4 @@ public class UserFacade {
             .build()
     );
   }
-
 }

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -103,14 +103,14 @@ public class LetterController {
    * 특정 편지를 저장하는 API (멘티, 멘토 공통)
    *
    * @param request   HTTP 요청 객체 (사용자 인증 정보 포함)
-   * @param letterSeq 저장할 편지의 고유 식별자 (ID)
+   * @param letterStatusSeq 저장할 편지의 고유 식별자 (ID)
    * @return 저장 결과 응답 (성공/실패 여부 포함)
    */
   @GetMapping("/save")
   public ResponseEntity<ResultResponse> saveLetter(HttpServletRequest request,
-      @RequestParam(name = "letterSeq") Long letterSeq) {
+      @RequestParam(name = "letterStatusSeq") Long letterStatusSeq) {
 
-    ResultResponse response = letterService.saveLetter(request, letterSeq);
+    ResultResponse response = letterService.saveLetter(request, letterStatusSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
@@ -118,14 +118,29 @@ public class LetterController {
    * 편지 상세 조회 API
    *
    * @param request   HTTP 요청 객체 (사용자 인증 정보 포함)
-   * @param letterSeq 조회할 편지의 고유 식별자 (ID)
+   * @param letterStatusSeq 조회할 편지의 고유 식별자 (ID)
    * @return 편지 상세 정보 응답 (성공/실패 여부 포함)
    */
   @GetMapping("/details")
   public ResponseEntity<ResultResponse> getLetterDetails(HttpServletRequest request,
-      @RequestParam(name = "letterSeq") Long letterSeq) {
+      @RequestParam(name = "letterStatusSeq") Long letterStatusSeq) {
 
-    ResultResponse response = letterService.getLetterDetails(request, letterSeq);
+    ResultResponse response = letterService.getLetterDetails(request, letterStatusSeq);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 편지 전달(Throw) API
+   *
+   * @param request           HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param letterStatusSeq   전달할 편지의 고유 식별자 (ID)
+   * @return                  결과 응답 객체 (성공/실패 여부 포함)
+   */
+  @GetMapping("/throw")
+  public ResponseEntity<ResultResponse> throwLetter(HttpServletRequest request,
+      @RequestParam(name = "letterStatusSeq") Long letterStatusSeq) {
+
+    ResultResponse response = letterService.throwLetter(request, letterStatusSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterEntity.java
@@ -21,6 +21,8 @@ public class LetterEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long letterSeq;
 
+  private String birdName;
+
   private String categoryName;
 
   private String letterTitle;

--- a/EnF/src/main/java/com/enf/entity/ThrowLetterEntity.java
+++ b/EnF/src/main/java/com/enf/entity/ThrowLetterEntity.java
@@ -1,0 +1,32 @@
+package com.enf.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "throw_letter")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ThrowLetterEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long throwLetterSeq;
+
+  @ManyToOne
+  @JoinColumn(name = "throw_user_seq")
+  private UserEntity throwUser;
+
+  @ManyToOne
+  @JoinColumn(name = "letter_status_seq")
+  private LetterStatusEntity letterStatus;
+}

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/ReplyLetterDTO.java
@@ -9,14 +9,8 @@ import lombok.Getter;
 @Getter
 public class ReplyLetterDTO {
 
-  @JsonProperty("letterSeq")
-  private Long letterSeq;
-
-  @JsonProperty("categoryName")
-  private String categoryName;
-
-  @JsonProperty("receiveUser")
-  private String receiveUser;
+  @JsonProperty("letterStatusSeq")
+  private Long letterStatusSeq;
 
   @JsonProperty("title")
   private String title;
@@ -25,18 +19,16 @@ public class ReplyLetterDTO {
   private String letter;
 
   @JsonCreator
-  public ReplyLetterDTO(Long letterSeq, String categoryName, String receiveUser, String title, String letter) {
-    this.letterSeq = letterSeq;
-    this.categoryName = categoryName;
-    this.receiveUser = receiveUser;
+  public ReplyLetterDTO(Long letterStatusSeq, String title, String letter) {
+    this.letterStatusSeq = letterStatusSeq;
     this.title = title;
     this.letter = letter;
   }
 
-  public static LetterEntity of(ReplyLetterDTO replyLetter) {
+  public static LetterEntity of(ReplyLetterDTO replyLetter, String categoryName) {
 
     return LetterEntity.builder()
-        .categoryName(replyLetter.getCategoryName())
+        .categoryName(categoryName)
         .letterTitle(replyLetter.getTitle())
         .letter(replyLetter.getLetter())
         .createAt(LocalDateTime.now())

--- a/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/letter/SendLetterDTO.java
@@ -32,6 +32,7 @@ public class SendLetterDTO {
 
   public static LetterEntity of(SendLetterDTO sendLetter) {
     return LetterEntity.builder()
+        .birdName(sendLetter.birdName)
         .categoryName(sendLetter.getCategoryName())
         .letterTitle(sendLetter.getTitle())
         .letter(sendLetter.getLetter())

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
@@ -15,20 +15,23 @@ public class LetterDetailsDTO {
   private LetterDTO sendLetter;
 
   public static LetterDetailsDTO ofMentee(LetterStatusEntity letterStatus) {
+    LetterDTO replyLetter;
+    LetterDTO sendLetter;
 
-    LetterDTO replyLetter = letterStatus.getMentorLetter() == null
-        ? null
-        : LetterDTO.of(
-        letterStatus.getMentor(),
-        letterStatus.getMentor(),
-        letterStatus.getMentorLetter()
-    );
+    if (letterStatus.getMentorLetter() == null) {
+      sendLetter = LetterDTO.of(null, letterStatus.getMentee(), letterStatus.getMenteeLetter());
+      return new LetterDetailsDTO(null, sendLetter);
+    }
 
-        LetterDTO sendLetter = LetterDTO.of(
-        null,
+    replyLetter = LetterDTO.of(
         letterStatus.getMentee(),
-        letterStatus.getMenteeLetter()
-    );
+        letterStatus.getMentor(),
+        letterStatus.getMentorLetter());
+
+    sendLetter = LetterDTO.of(
+        letterStatus.getMentor(),
+        letterStatus.getMentee(),
+        letterStatus.getMenteeLetter());
 
     return new LetterDetailsDTO(replyLetter, sendLetter);
   }
@@ -36,14 +39,18 @@ public class LetterDetailsDTO {
   public static LetterDetailsDTO ofMentor(LetterStatusEntity letterStatus) {
 
     LetterDTO replyLetter = LetterDTO.of(
-        letterStatus.getMentee(),
         letterStatus.getMentor(),
+        letterStatus.getMentee(),
         letterStatus.getMenteeLetter()
     );
 
+    if (letterStatus.getMentorLetter() == null) {
+      return new LetterDetailsDTO(replyLetter, null);
+    }
+
     LetterDTO sendLetter = LetterDTO.of(
-        letterStatus.getMentor(),
         letterStatus.getMentee(),
+        letterStatus.getMentor(),
         letterStatus.getMentorLetter()
     );
 

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReceiveLetterDTO {
 
-  private Long letterSeq;
+  private Long letterStatusSeq;
 
   private String birdName;
 

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -16,6 +16,9 @@ public enum FailedResultType {
   REFRESH_TOKEN_IS_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다!"),
   BAD_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "발급된 Refresh 토큰이 아닙니다."),
   LETTER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 편지 일련번호 입니다."),
+  MENTEE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "멘티는 접근 권한이 없습니다."),
+  MENTOR_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "멘토는 접근 권한이 없습니다."),
+  ALREADY_REPLIED(HttpStatus.BAD_REQUEST, "이미 답장한 편지는 넘길 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -22,6 +22,7 @@ public enum SuccessResultType {
   SUCCESS_GET_SAVE_LETTER(HttpStatus.OK, "저장한 편지 조회 성공"),
   SUCCESS_SAVE_LETTER(HttpStatus.OK, "편지 저장 성공"),
   SUCCESS_GET_LETTER_DETAILS(HttpStatus.OK, "편지 상세 조회 성공"),
+  SUCCESS_THROW_LETTER(HttpStatus.OK, "편지 넘기기 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -2,6 +2,7 @@ package com.enf.repository;
 
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
+import com.enf.entity.UserEntity;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,35 +18,41 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
   @Transactional
   @Query("UPDATE letter_status ls "
       + "SET ls.mentorLetter = :mentorLetter, ls.createAt = CURRENT_TIMESTAMP "
-      + "WHERE ls.menteeLetter = :menteeLetter")
+      + "WHERE ls.letterStatusSeq = :letterStatusSeq")
   void updateLetterStatus(
-      @Param("mentorLetter") LetterEntity mentorLetter,
-      @Param("menteeLetter") LetterEntity menteeLetter
+      @Param("letterStatusSeq") Long letterStatusSeq,
+      @Param("mentorLetter") LetterEntity mentorLetter
   );
 
   @Modifying
   @Transactional
   @Query("UPDATE letter_status ls "
-      + "SET ls.isMenteeSaved = true WHERE ls.letterStatusSeq = :letterSeq")
-  void saveLetterForMentee(@Param("letterSeq") Long letterSeq);
+      + "SET ls.isMenteeSaved = true WHERE ls.letterStatusSeq = :letterStatusSeq")
+  void saveLetterForMentee(@Param("letterStatusSeq") Long letterStatusSeq);
 
   @Modifying
   @Transactional
   @Query("UPDATE letter_status ls "
-      + "SET ls.isMentorSaved = true WHERE ls.letterStatusSeq = :letterSeq")
-  void saveLetterForMentor(@Param("letterSeq") Long letterSeq);
+      + "SET ls.isMentorSaved = true WHERE ls.letterStatusSeq = :letterStatusSeq")
+  void saveLetterForMentor(@Param("letterStatusSeq") Long letterStatusSeq);
 
-  Optional<LetterStatusEntity> findLetterStatusByLetterStatusSeq(Long letterSeq);
-
-  @Modifying
-  @Transactional
-  @Query("UPDATE letter_status ls "
-      + "SET ls.isMenteeRead = true WHERE ls.letterStatusSeq = :letterSeq")
-  void updateIsMenteeRead(@Param("letterSeq") Long letterSeq);
+  Optional<LetterStatusEntity> findLetterStatusByLetterStatusSeq(Long letterStatusSeq);
 
   @Modifying
   @Transactional
   @Query("UPDATE letter_status ls "
-      + "SET ls.isMentorRead = true WHERE ls.letterStatusSeq = :letterSeq")
-  void updateIsMentorRead(@Param("letterSeq") Long letterSeq);
+      + "SET ls.isMenteeRead = true WHERE ls.letterStatusSeq = :letterStatusSeq")
+  void updateIsMenteeRead(@Param("letterStatusSeq") Long letterStatusSeq);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.isMentorRead = true WHERE ls.letterStatusSeq = :letterStatusSeq")
+  void updateIsMentorRead(@Param("letterStatusSeq") Long letterStatusSeq);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls "
+      + "SET ls.mentor = :newMentor, ls.isMentorRead = false WHERE ls.letterStatusSeq = :letterStatusSeq")
+  void updateMentor(@Param("letterStatusSeq") Long letterStatusSeq, @Param("newMentor")UserEntity newMentor);
 }

--- a/EnF/src/main/java/com/enf/repository/ThrowLetterRepository.java
+++ b/EnF/src/main/java/com/enf/repository/ThrowLetterRepository.java
@@ -1,0 +1,10 @@
+package com.enf.repository;
+
+import com.enf.entity.ThrowLetterEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ThrowLetterRepository extends JpaRepository<ThrowLetterEntity, Long> {
+
+}

--- a/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
@@ -1,18 +1,22 @@
 package com.enf.repository.querydsl;
 
+import static java.util.Optional.ofNullable;
+
 import com.enf.entity.QQuotaEntity;
 import com.enf.entity.QThrowLetterEntity;
 import com.enf.entity.QUserEntity;
 import com.enf.entity.UserEntity;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
-/**
- * QueryDSL을 활용한 사용자 조회 Repository
- */
+
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class UserQueryRepository {
@@ -23,87 +27,121 @@ public class UserQueryRepository {
   QThrowLetterEntity throwLetter = QThrowLetterEntity.throwLetterEntity;
 
   /**
-   * 특정 조건에 맞는 사용자 조회
+   * 멘토 조회 메서드
    *
-   * @param birdName     새 유형
+   * 우선순위에 따라 멘토를 조회한다.
+   * 1순위: 새 유형과 카테고리가 모두 일치하는 멘토
+   * 2순위: 카테고리만 일치하는 멘토
+   * 3순위: 새 유형만 일치하는 멘토
+   * 4순위: (추가 예정)
+   * 5순위: 랜덤 멘토
+   * 6순위: 관리자 (추가 예정)
+   *
+   * @param birdName 새 유형
    * @param categoryName 카테고리명
-   * @return 조건에 맞는 사용자 엔티티
+   * @param letterStatusSeq 편지를 넘긴 이력 확인을 위한 식별자
+   * @return 조건에 맞는 사용자 엔티티 (멘토) 또는 null
    */
-  public UserEntity getMentor(String birdName, String categoryName) {
-
-    // 1순위: 새 유형과 카테고리가 모두 일치하는 사용자
-    // 2순위: 카테고리만 일치하는 사용자
-    // 3순위: 새 유형만 일치하는 사용자
-    // 4순위: 추가 예정
-    // 5순위: 랜덤
-    // 6순위: 관리자
-
-    return fetchUser(user.bird.birdName.eq(birdName), getCategoryPredicate(user, categoryName), getQuotaPredicate(quota))
-        .or(() -> fetchUser(getCategoryPredicate(user, categoryName), getQuotaPredicate(quota)))
-        .or(() -> fetchUser(user.bird.birdName.eq(birdName), getQuotaPredicate(quota)))
-        .orElse(randomUser(getQuotaPredicate(quota)));
+  public UserEntity getMentor(String birdName, String categoryName, Long letterStatusSeq) {
+    return fetchUser(buildConditions(birdName, categoryName, letterStatusSeq))
+        .orElseGet(() -> fetchUser(buildConditions(null, categoryName, letterStatusSeq))
+            .orElseGet(() -> fetchUser(buildConditions(birdName, null, letterStatusSeq))
+                .orElseGet(() -> randomUser(buildConditions(null, null, letterStatusSeq)))));
   }
 
   /**
-   * 주어진 조건을 기반으로 사용자 조회
+   * 조건을 기반으로 멘토를 조회하는 메서드
    *
-   * @param conditions BooleanExpression (검색 조건)
-   * @return 조건에 맞는 첫 번째 사용자 엔티티 또는 null
+   * @param builder QueryDSL의 BooleanBuilder (검색 조건)
+   * @return 조건에 맞는 첫 번째 사용자 엔티티 (Optional)
    */
-  private Optional<UserEntity> fetchUser(BooleanExpression... conditions) {
-
-    return Optional.ofNullable(
-        jpaQueryFactory
-            .selectFrom(user)
-            .join(quota).on(user.userSeq.eq(quota.user.userSeq))
-            .where(user.role.roleName.eq("MENTOR"),
-                user.ne(throwLetter.throwUser))
-            .where(conditions)
-            .orderBy(quota.quota.desc())
-            .fetchFirst()
-    );
+  private Optional<UserEntity> fetchUser(BooleanBuilder builder) {
+    log.info(builder.toString());
+    return ofNullable(jpaQueryFactory
+        .selectFrom(user)
+        .join(quota).on(user.userSeq.eq(quota.user.userSeq))
+        .where(builder)
+        .orderBy(quota.quota.desc())
+        .fetchFirst());
   }
 
-  private UserEntity randomUser(BooleanExpression... conditions) {
-
+  /**
+   * 랜덤 멘토를 조회하는 메서드
+   *
+   * @param builder QueryDSL의 BooleanBuilder (검색 조건)
+   * @return 조건에 맞는 랜덤 멘토 (첫 번째 결과 반환)
+   */
+  private UserEntity randomUser(BooleanBuilder builder) {
     return jpaQueryFactory
-            .selectFrom(user)
-            .join(quota).on(user.userSeq.eq(quota.user.userSeq))
-            .where(user.role.roleName.eq("MENTOR"),
-                user.ne(throwLetter.throwUser))
-            .where(conditions)
-            .orderBy(quota.quota.desc())
-            .fetchFirst();
-
+        .selectFrom(user)
+        .join(quota).on(user.userSeq.eq(quota.user.userSeq))
+        .where(builder)
+        .orderBy(quota.quota.desc())
+        .fetchFirst();
   }
 
   /**
-   * 카테고리명에 따른 검색 조건 반환
+   * 카테고리명에 따른 검색 조건을 반환하는 메서드
    *
-   * @param user        사용자 엔티티
+   * @param user 사용자 엔티티
    * @param categoryName 카테고리명
-   * @return BooleanExpression (검색 조건)
+   * @return BooleanExpression (해당 카테고리가 true인 조건)
    */
   private BooleanExpression getCategoryPredicate(QUserEntity user, String categoryName) {
     if (categoryName == null || categoryName.isEmpty()) return null;
-
     return switch (categoryName) {
-      case "career" -> user.category.career.isTrue();
-      case "mental" -> user.category.mental.isTrue();
-      case "relationship" -> user.category.relationship.isTrue();
-      case "love" -> user.category.love.isTrue();
-      case "life" -> user.category.life.isTrue();
-      case "finance" -> user.category.finance.isTrue();
-      case "housing" -> user.category.housing.isTrue();
-      case "other" -> user.category.other.isTrue();
+      case "career" -> user.category.career.eq(true);
+      case "mental" -> user.category.mental.eq(true);
+      case "relationship" -> user.category.relationship.eq(true);
+      case "love" -> user.category.love.eq(true);
+      case "life" -> user.category.life.eq(true);
+      case "finance" -> user.category.finance.eq(true);
+      case "housing" -> user.category.housing.eq(true);
+      case "other" -> user.category.other.eq(true);
       default -> null;
     };
   }
 
   /**
-   * Quota 조건 반환
+   * 멘토 조회 조건을 생성하는 메서드
+   *
+   * @param birdName 새 유형
+   * @param categoryName 카테고리명
+   * @param letterStatusSeq 편지를 넘긴 이력을 조회하기 위한 식별자
+   * @return BooleanBuilder (QueryDSL 검색 조건)
    */
-  private BooleanExpression getQuotaPredicate(QQuotaEntity quota) {
-    return quota.quota.goe(1); // quota >= 1 조건 추가
+  private BooleanBuilder buildConditions(String birdName, String categoryName, Long letterStatusSeq) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    builder.and(user.role.roleName.eq("MENTOR"));
+    builder.and(quota.quota.goe(1));
+
+    if (birdName != null) {
+      builder.and(user.bird.birdName.eq(birdName));
+    }
+    if (categoryName != null) {
+      builder.and(getCategoryPredicate(user, categoryName));
+    }
+
+    if (letterStatusSeq != null) {
+      List<UserEntity> userList = getUsersWhoThrownLetter(letterStatusSeq);
+      builder.and(user.notIn(userList));
+    }
+
+    return builder;
+  }
+
+  /**
+   * 특정 편지를 넘긴 사용자 목록을 조회하는 메서드
+   *
+   * @param letterId 편지 ID
+   * @return 해당 편지를 넘긴 사용자 리스트
+   */
+  public List<UserEntity> getUsersWhoThrownLetter(Long letterId) {
+    return jpaQueryFactory
+        .select(throwLetter.throwUser)
+        .from(throwLetter)
+        .where(throwLetter.letterStatus.letterStatusSeq.eq(letterId))
+        .fetch();
   }
 }

--- a/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/UserQueryRepository.java
@@ -1,6 +1,7 @@
 package com.enf.repository.querydsl;
 
 import com.enf.entity.QQuotaEntity;
+import com.enf.entity.QThrowLetterEntity;
 import com.enf.entity.QUserEntity;
 import com.enf.entity.UserEntity;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -19,6 +20,7 @@ public class UserQueryRepository {
   private final JPAQueryFactory jpaQueryFactory;
   QUserEntity user = QUserEntity.userEntity;
   QQuotaEntity quota = QQuotaEntity.quotaEntity;
+  QThrowLetterEntity throwLetter = QThrowLetterEntity.throwLetterEntity;
 
   /**
    * 특정 조건에 맞는 사용자 조회
@@ -54,7 +56,8 @@ public class UserQueryRepository {
         jpaQueryFactory
             .selectFrom(user)
             .join(quota).on(user.userSeq.eq(quota.user.userSeq))
-            .where(user.role.roleName.eq("MENTOR"))
+            .where(user.role.roleName.eq("MENTOR"),
+                user.ne(throwLetter.throwUser))
             .where(conditions)
             .orderBy(quota.quota.desc())
             .fetchFirst()
@@ -66,7 +69,8 @@ public class UserQueryRepository {
     return jpaQueryFactory
             .selectFrom(user)
             .join(quota).on(user.userSeq.eq(quota.user.userSeq))
-            .where(user.role.roleName.eq("MENTOR"))
+            .where(user.role.roleName.eq("MENTOR"),
+                user.ne(throwLetter.throwUser))
             .where(conditions)
             .orderBy(quota.quota.desc())
             .fetchFirst();

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -17,7 +17,9 @@ public interface LetterService {
 
   ResultResponse getSaveLetterList(HttpServletRequest request, int pageNumber);
 
-  ResultResponse saveLetter(HttpServletRequest request, Long letterSeq);
+  ResultResponse saveLetter(HttpServletRequest request, Long letterStatusSeq);
 
-  ResultResponse getLetterDetails(HttpServletRequest request, Long letterSeq);
+  ResultResponse getLetterDetails(HttpServletRequest request, Long letterStatusSeq);
+
+  ResultResponse throwLetter(HttpServletRequest request, Long letterStatusSeq);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -200,11 +200,11 @@ public class LetterServiceImpl implements LetterService {
       throw new GlobalException(FailedResultType.ALREADY_REPLIED);
     }
 
-    String birdName = letterStatus.getMentee().getBird().getBirdName();
-    String categoryName = letterStatus.getMenteeLetter().getCategoryName();
+    letterFacade.throwLetter(letterStatus);
+    UserEntity newMentor = userFacade.getNewMentor(letterStatus);
 
-    UserEntity newMentor = userFacade.getMentorByBirdAndCategory(birdName, categoryName);
-    letterFacade.throwLetter(letterStatus, newMentor);
+    letterFacade.updateMentor(letterStatus, newMentor);
+    redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(letterStatus.getMentee(), newMentor));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_THROW_LETTER);
   }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

#### LetterFacade
   - 수정 사항
      - ThrowLetterRepository 추가
      - saveMentorLetter() 메서드 수정
         - 기존 menteeLetter를 직접 참조하는 방식에서 letterStatusSeq를 통해 조회 후 업데이트하도록 변경
      - saveLetter() 메서드 수정
         - letterSeq → letterStatusSeq로 변경
      - getLetterDetails() 메서드 수정
         - letterSeq → LetterStatusEntity letterStatus로 변경

   - 추가된 기능
      - throwLetter() 메서드 추가
         - 기존 멘토에서 새로운 멘토로 편지를 전달하는 기능 추가
         - ThrowLetterEntity를 생성하여 저장하는 로직 추가

#### UserFacade
   - 수정 사항
      - getMentorByBirdAndCategory() 메서드 수정
         - SendLetterDTO 전체를 받는 방식에서 birdName, categoryName을 개별 인자로 받는 방식으로 변경

#### LetterController
   - 수정 사항
      - letterSeq → letterStatusSeq로 변경 (@RequestParam)

   - 추가된 기능
      - 편지 넘기기 위한 throwLetter() API 추가

#### LetterService & LetterServiceImpl
   - 수정 사항
      - sendLetter()에서 getMentorByBirdAndCategory() 호출 방식 변경
         - 중복으로 호출하는 메서드가 존재해서 SendLetterDTO 대신 birdName, categoryName을 개별 인자로 전달
      - replyLetter()에서 getLetterStatus()를 사용하여 LetterStatusEntity를 가져오도록 변경
         - saveLetter(), getLetterDetails()에서 letterSeq → letterStatusSeq로 변경

   - 추가된 기능
      - throwLetter() 메서드 추가
      - 멘티가 편지를 던질 수 없도록 MENTEE_PERMISSION_DENIED 예외 처리 추가
      - ALREADY_REPLIED 예외 처리 추가
      - ThrowLetterEntity 저장 추가

#### ThrowLetterEntity
   - 추가된 기능
      - 기존 멘토 정보를 저장하는 역할
         - 편지를 넘긴 사용자는 같은 편지를 다시 받으면 안되기 때문에 해당 테이블을 구현 
      - letterStatus와 throwUser(이전 멘토)를 저장하는 구조

#### ThrowLetterRepository
   - 추가된 기능
      - ThrowLetterEntity 저장을 위한 JpaRepository 추가

#### LetterStatusRepository
   - 수정 사항
      - letterSeq → letterStatusSeq로 변경

   - 추가된 기능
      - updateMentor() 메서드 추가
      - 멘토 변경 시 isMentorRead를 false로 설정
         - 만약 기존 멘토가 넘길 경우 isMentorRead가 true로 되어 있기 편지를 넘긴다면 false로 변경

#### ReplyLetterDTO
   - 수정 사항
      - etterSeq → letterStatusSeq로 필드명 변경
      - categoryName, receiveUser 필드 제거
      - of() 메서드 수정
      - categoryName을 메서드 파라미터로 받도록 변경

#### LetterDetailsDTO
   - 수정 사항
      - 기존 sendLetter, replyLetter 초기화 방식 변경
      - null 체크 및 할당 로직을 보다 명확하게 수정

#### ReceiveLetterDTO
   - 수정 사항
      - letterSeq → letterStatusSeq로 필드명 변경

## 스크린샷

## 주의사항

Closes #46
