### PR TITLE
[feat] CORS 정책 설정을 위한 CorsConfig 클래스 구현

### DIFF
--- a/EnF/src/main/java/com/enf/config/CorsConfig.java
+++ b/EnF/src/main/java/com/enf/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package com.enf.config;
+
+import com.enf.model.type.TokenType;
+import com.enf.model.type.UrlType;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+  private static final String ALLOW_METHOD_NAMES = "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT";
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+
+    registry.addMapping("/**") // CORS 설정을 모든 URL에 적용
+
+        .allowedOrigins(UrlType.FRONT_URL.getUrl())
+        .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
+        .allowedHeaders("*")        // 모든 HTTP header 허용
+        .allowCredentials(true)     // 자격 증명 허용
+        .exposedHeaders(
+            TokenType.ACCESS.getValue(),
+            HttpHeaders.LOCATION,
+            HttpHeaders.CONTENT_TYPE);   // 클라이언트에 노출할 헤더 목록
+  }
+
+}

--- a/EnF/src/main/java/com/enf/config/CorsConfig.java
+++ b/EnF/src/main/java/com/enf/config/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig implements WebMvcConfigurer {
 
     registry.addMapping("/**") // CORS 설정을 모든 URL에 적용
 
-        .allowedOrigins(UrlType.FRONT_URL.getUrl())
+        .allowedOrigins(UrlType.FRONT_LOCAL_URL.getUrl())
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용

--- a/EnF/src/main/java/com/enf/model/type/UrlType.java
+++ b/EnF/src/main/java/com/enf/model/type/UrlType.java
@@ -7,7 +7,7 @@ public enum UrlType {
 
   KAKAO_TOKEN_URL("https://kauth.kakao.com/oauth/token"),
   KAKAO_USER_INFO_URL("https://kapi.kakao.com/v2/user/me"),
-  FRONT_URL("추가 예정"),
+  FRONT_LOCAL_URL("http://localhost:3000"),
   ;
 
   private final String url;

--- a/EnF/src/main/java/com/enf/model/type/UrlType.java
+++ b/EnF/src/main/java/com/enf/model/type/UrlType.java
@@ -7,6 +7,7 @@ public enum UrlType {
 
   KAKAO_TOKEN_URL("https://kauth.kakao.com/oauth/token"),
   KAKAO_USER_INFO_URL("https://kapi.kakao.com/v2/user/me"),
+  FRONT_URL("추가 예정"),
   ;
 
   private final String url;


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
CORS 정책 설정을 위한 CorsConfig 클래스 구현

   - addMapping("/**")
      - 모든 API 경로에 CORS 적용
   - allowedOrigins(UrlType.FRONT_URL.getUrl())
      - 보안 강화를 위해 특정 도메인만 허용(프론트 측 URL)
   - allowedMethods(ALLOW_METHOD_NAMES.split(","))
      - HTTP 요청 메서드 제한 없이 허용
   - allowedHeaders("*")
      -모든 요청 헤더 허용
   - allowCredentials(true)
      - 쿠키 및 인증 정보 포함 허용
   - exposedHeaders(TokenType.ACCESS.getValue(), HttpHeaders.LOCATION, HttpHeaders.CONTENT_TYPE)
      - 클라이언트가 접근할 수 있는 헤더 지정

## 스크린샷

## 주의사항

Closes #49 
