### PR TITLE
[feat] 고마움 전달하기 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -208,4 +208,13 @@ public class LetterFacade {
   public void updateMentor(LetterStatusEntity letterStatus, UserEntity newMentor) {
     letterStatusRepository.updateMentor(letterStatus.getLetterStatusSeq(), newMentor);
   }
+
+  public LetterStatusEntity thanksToMentor(Long letterSeq) {
+    LetterStatusEntity letterStatus = letterStatusRepository
+        .getLetterStatusByMentorLetterLetterSeq(letterSeq);
+
+    letterStatusRepository.updateIsThankToMentor(letterStatus.getLetterStatusSeq());
+
+    return letterStatus;
+  }
 }

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -83,6 +83,7 @@ public class LetterFacade {
             .isMentorRead(false)
             .isMenteeSaved(false)
             .isMentorSaved(false)
+            .isThanksToMentor(false)
             .createAt(LocalDateTime.now())
             .build()
     );

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -209,6 +209,11 @@ public class LetterFacade {
     letterStatusRepository.updateMentor(letterStatus.getLetterStatusSeq(), newMentor);
   }
 
+  /**
+   * 고마움 전달을 위한 메서드
+   *
+   * @param letterSeq 고마움을 전달할 멘토 편지의 고유 식별자
+   */
   public LetterStatusEntity thanksToMentor(Long letterSeq) {
     LetterStatusEntity letterStatus = letterStatusRepository
         .getLetterStatusByMentorLetterLetterSeq(letterSeq);

--- a/EnF/src/main/java/com/enf/config/JwtTokenFilter.java
+++ b/EnF/src/main/java/com/enf/config/JwtTokenFilter.java
@@ -38,9 +38,9 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return;
         }
 
+        log.info("request URI : {}", request.getRequestURI());
         // 검증 필요한 경로인지 확인
         if(isExcludedPath(request.getRequestURI())) {
-            log.info("request URI : {}", request.getRequestURI());
             filterChain.doFilter(request, response);
             return;
         }

--- a/EnF/src/main/java/com/enf/config/JwtTokenFilter.java
+++ b/EnF/src/main/java/com/enf/config/JwtTokenFilter.java
@@ -102,6 +102,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         return requestURI.equals("/")
             || requestURI.equals("/api/v1/auth/callback")
             || requestURI.equals("/api/v1/auth/kakao")
-            || requestURI.equals("/api/v1/auth/reissue-token");
+            || requestURI.equals("/api/v1/auth/reissue-token")
+            || requestURI.matches("/v3/api-docs/.*")
+            || requestURI.matches("/v3/api-docs")
+            || requestURI.matches("/swagger-ui/.*")
+            || requestURI.equals("/swagger-ui.html")
+            || requestURI.matches("/swagger-resources/.*");
     }
 }

--- a/EnF/src/main/java/com/enf/config/SecurityConfig.java
+++ b/EnF/src/main/java/com/enf/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session->session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(                         // 경로별 인가 설정
                 authorizeRequests -> authorizeRequests
+                                .requestMatchers(SecurityConstants.swaggerUrls).permitAll()
                                 .requestMatchers(SecurityConstants.allowedUrls).permitAll()  // 허용 URL 설정
                                 .requestMatchers(SecurityConstants.adminUrls).hasAnyAuthority("ADMIN","DEVELOPER") // 관리자만 접근 가능
                                 .requestMatchers(SecurityConstants.userUrls).hasAnyAuthority("UNKNOWN","MENTEE","MENTOR","ADMIN","DEVELOPER") // 주니어 사용자 접근 가능

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -6,6 +6,7 @@ import com.enf.model.dto.response.ResultResponse;
 import com.enf.service.LetterService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -141,6 +142,21 @@ public class LetterController {
       @RequestParam(name = "letterStatusSeq") Long letterStatusSeq) {
 
     ResultResponse response = letterService.throwLetter(request, letterStatusSeq);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 편지 전달(Throw) API
+   *
+   * @param request           HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param letterSeq         고마움 표시할 멘토 편지의 고유 식별자 (ID)
+   * @return                  결과 응답 객체 (성공/실패 여부 포함)
+   */
+  @GetMapping("/thanks")
+  public ResponseEntity<ResultResponse> thanksToMentor(HttpServletRequest request,
+      @RequestParam(name = "letterSeq") Long letterSeq) {
+
+    ResultResponse response = letterService.thanksToMentor(request, letterSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -52,5 +52,8 @@ public class LetterStatusEntity {
   @Column(name = "is_mentor_saved")
   private boolean isMentorSaved;
 
+  @Column(name = "is_thanks_to_mentor")
+  private boolean isThanksToMentor;
+
   private LocalDateTime createAt;
 }

--- a/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
@@ -34,6 +34,17 @@ public class NotificationDTO {
   }
 
   /**
+   * 멘티가 고마움 표시를 보냈을 때 생성되는 알림
+   */
+  public static NotificationDTO thanksToMentor(UserEntity mentee, UserEntity mentor) {
+    return new NotificationDTO(
+        mentor.getUserSeq(),
+        mentee.getNickname(),
+        mentee.getNickname() + " 버디가 고마움 표시를 남겼어요~"
+    );
+  }
+
+  /**
    * 멘티가 편지를 보냈을 때 생성되는 알림
    */
   public static NotificationDTO sendLetter(UserEntity mentee, UserEntity mentor) {

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -23,6 +23,7 @@ public enum SuccessResultType {
   SUCCESS_SAVE_LETTER(HttpStatus.OK, "편지 저장 성공"),
   SUCCESS_GET_LETTER_DETAILS(HttpStatus.OK, "편지 상세 조회 성공"),
   SUCCESS_THROW_LETTER(HttpStatus.OK, "편지 넘기기 성공"),
+  SUCCESS_THANKS_TO_MENTOR(HttpStatus.OK, "고마움 표시하기 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -56,5 +56,13 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
   @Transactional
   @Query("UPDATE letter_status ls "
       + "SET ls.mentor = :newMentor, ls.isMentorRead = false WHERE ls.letterStatusSeq = :letterStatusSeq")
-  void updateMentor(@Param("letterStatusSeq") Long letterStatusSeq, @Param("newMentor")UserEntity newMentor);
+  void updateMentor(@Param("letterStatusSeq") Long letterStatusSeq,
+      @Param("newMentor") UserEntity newMentor);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE letter_status ls SET ls.isThanksToMentor = true WHERE ls.letterStatusSeq =:letterStatusSeq")
+  void updateIsThankToMentor(Long letterStatusSeq);
+
+  LetterStatusEntity getLetterStatusByMentorLetterLetterSeq(Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -22,4 +22,6 @@ public interface LetterService {
   ResultResponse getLetterDetails(HttpServletRequest request, Long letterStatusSeq);
 
   ResultResponse throwLetter(HttpServletRequest request, Long letterStatusSeq);
+
+  ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -208,4 +208,19 @@ public class LetterServiceImpl implements LetterService {
 
     return ResultResponse.of(SuccessResultType.SUCCESS_THROW_LETTER);
   }
+
+  @Override
+  public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    if(user.getRole().getRoleName().equals("MENTOR")) {
+      throw new GlobalException(FailedResultType.MENTOR_PERMISSION_DENIED);
+    }
+
+    LetterStatusEntity letterStatus = letterFacade.thanksToMentor(letterSeq);
+    redisTemplate.convertAndSend("notifications", NotificationDTO
+        .thanksToMentor(letterStatus.getMentee(), letterStatus.getMentor()));
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_THANKS_TO_MENTOR);
+  }
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -209,6 +209,14 @@ public class LetterServiceImpl implements LetterService {
     return ResultResponse.of(SuccessResultType.SUCCESS_THROW_LETTER);
   }
 
+  /**
+   * 고마움 전달 로직을 수행하는 메서드
+   *
+   * @param request          HTTP 요청 객체 (사용자 인증 정보 포함)
+   * @param letterSeq        고마움을 전달할 멘토 편지의 고유 식별자 (ID)
+   * @return                 결과 응답 객체 (성공/실패 여부 포함)
+   * @throws GlobalException 멘토가 해당 경로를 호출할 경우 예외처리
+   */
   @Override
   public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq) {
     UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
#### LetterFacade
- `isThanksToMentor` 필드 추가하여 멘토에게 고마움을 표시하는 기능 추가.
- `thanksToMentor(Long letterSeq)` 메서드 추가하여 특정 편지에 대한 고마움 전달 로직 구현.

#### JwtTokenFilter
- `log.info("request URI : {}")`  로그 위치 변경
- 인증이 필요 없는 Swagger 관련 경로 추가 (`/v3/api-docs/.*`, `/swagger-ui/.*`, `/swagger-resources/.*`).

#### SecurityConfig
- Swagger 관련 경로를 허용 목록에 추가 (`requestMatchers(SecurityConstants.swaggerUrls).permitAll()`).

#### LetterController
- `thanksToMentor` API (`GET /thanks`) 추가하여 고마움 전달 기능 구현.

####LetterStatusEntity
- `isThanksToMentor` 필드 추가하여 멘토에게 고마움을 표시할 수 있도록 확장.

#### NotificationDTO
- `thanksToMentor` 정적 메서드 추가하여 멘토가 고마움을 받았을 때 알림을 생성하도록 변경.

#### SuccessResultType
- `SUCCESS_THANKS_TO_MENTOR` 응답 타입 추가 (`"고마움 표시하기 성공"`).

#### LetterStatusRepository
- `updateIsThankToMentor(Long letterStatusSeq)` 메서드 추가하여 특정 편지 상태를 업데이트하는 쿼리 추가.

#### LetterService (인터페이스)
- `thanksToMentor(HttpServletRequest request, Long letterSeq)` 메서드 추가.

#### LetterServiceImpl
- `thanksToMentor` 메서드 구현:
  - `MENTOR`가 요청하면 예외 발생 (`MENTOR_PERMISSION_DENIED`).
  - `letterFacade.thanksToMentor(letterSeq)` 호출하여 DB 업데이트.
  - `redisTemplate.convertAndSend("notifications", NotificationDTO.thanksToMentor(...))`를 통해 Redis Pub/Sub을 사용해 알림 전송.

## 스크린샷

## 주의사항

Closes #51 
