### PR TITLE
[refactor] 알림 전달 방식 String -> Object 형식으로 변경

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -69,12 +69,12 @@ public class LetterFacade {
    * @param mentee 편지를 보낸 멘티
    * @param mentor 편지를 받는 멘토
    */
-  public void saveMenteeLetter(LetterEntity letter, UserEntity mentee, UserEntity mentor) {
+  public LetterStatusEntity saveMenteeLetter(LetterEntity letter, UserEntity mentee, UserEntity mentor) {
     // 편지를 저장
     LetterEntity menteeLetter = letterRepository.save(letter);
 
     // 편지 상태 저장 (멘토가 답장할 때 참조할 수 있도록 함)
-    letterStatusRepository.save(
+    return letterStatusRepository.save(
         LetterStatusEntity.builder()
             .mentee(mentee)
             .mentor(mentor)

--- a/EnF/src/main/java/com/enf/entity/NotificationEntity.java
+++ b/EnF/src/main/java/com/enf/entity/NotificationEntity.java
@@ -23,6 +23,8 @@ public class NotificationEntity {
 
   private Long userSeq;
 
+  private Long letterStatusSeq;
+
   private String sendUser;
 
   private String message;

--- a/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/request/notification/NotificationDTO.java
@@ -1,5 +1,6 @@
 package com.enf.model.dto.request.notification;
 
+import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.NotificationEntity;
 import com.enf.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -17,52 +18,48 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NotificationDTO {
 
-  private Long userSeq;    // 알림을 받을 사용자 ID
-  private String sendUser; // 알림을 보낸 사용자 (없을 수도 있음)
-  private String message;  // 알림 메시지
+  private Long userSeq;           // 알림을 받을 사용자 ID
+  private Long letterStatusSeq;   // 보낸 편지의 일련번호
+  private String sendUser;        // 알림을 보낸 사용자 (없을 수도 있음)
+  private String message;         // 알림 메시지
 
 
-  /**
-   * SSE 구독 성공 시 생성되는 알림
-   */
-  public static NotificationDTO subscribe(UserEntity user) {
-    return new NotificationDTO(
-        user.getUserSeq(),
-        null,
-        user.getNickname() + " 버디 구독 성공!"
-    );
-  }
 
   /**
    * 멘티가 고마움 표시를 보냈을 때 생성되는 알림
    */
-  public static NotificationDTO thanksToMentor(UserEntity mentee, UserEntity mentor) {
+  public static NotificationDTO thanksToMentor(LetterStatusEntity letterStatus) {
     return new NotificationDTO(
-        mentor.getUserSeq(),
-        mentee.getNickname(),
-        mentee.getNickname() + " 버디가 고마움 표시를 남겼어요~"
+        letterStatus.getMentor().getUserSeq(),
+        letterStatus.getLetterStatusSeq(),
+        letterStatus.getMentee().getNickname(),
+        letterStatus.getMentee().getNickname() + "님으로부터 나의 답장에 대한 고마움 표시가 도착했어요."
+
     );
   }
 
   /**
    * 멘티가 편지를 보냈을 때 생성되는 알림
    */
-  public static NotificationDTO sendLetter(UserEntity mentee, UserEntity mentor) {
+  public static NotificationDTO sendLetter(
+      LetterStatusEntity letterStatus, UserEntity mentor) {
     return new NotificationDTO(
         mentor.getUserSeq(),
-        mentee.getNickname(),
-        mentee.getNickname() + " 버디가 편지를 보냈어요~"
+        letterStatus.getLetterStatusSeq(),
+        letterStatus.getMentee().getNickname(),
+        letterStatus.getMentee().getNickname() + "님으로부터 날아온 답장을 확인해보세요"
     );
   }
 
   /**
    * 멘토가 편지를 보냈을 때 생성되는 알림
    */
-  public static NotificationDTO replyLetter(UserEntity mentor, UserEntity mentee) {
+  public static NotificationDTO replyLetter(LetterStatusEntity letterStatus) {
     return new NotificationDTO(
-        mentee.getUserSeq(),
-        mentor.getNickname(),
-        mentor.getNickname() + " 버디가 편지를 보냈어요~"
+        letterStatus.getMentee().getUserSeq(),
+        letterStatus.getLetterStatusSeq(),
+        letterStatus.getMentor().getNickname(),
+        letterStatus.getMentor().getNickname() + "님으로부터 날아온 답장을 확인해보세요"
     );
   }
 
@@ -72,19 +69,9 @@ public class NotificationDTO {
   public static NotificationDTO of(Long userSeq, NotificationEntity notification) {
     return new NotificationDTO(
         userSeq,
+        notification.getLetterStatusSeq(),
         notification.getSendUser(),
         notification.getMessage()
-    );
-  }
-
-  /**
-   * 여러 개의 알림을 묶어서 보낼 때 사용
-   */
-  public static NotificationDTO of(Long userSeq, NotificationEntity notification, int size) {
-    return new NotificationDTO(
-        userSeq,
-        notification.getSendUser(),
-        notification.getSendUser() + "외 " + size + "명의 버디가 편지를 보냈어요~"
     );
   }
 
@@ -94,6 +81,7 @@ public class NotificationDTO {
   public static NotificationEntity toEntity(NotificationDTO notification) {
     return NotificationEntity.builder()
         .userSeq(notification.getUserSeq())
+        .letterStatusSeq(notification.getLetterStatusSeq())
         .sendUser(notification.getSendUser())
         .message(notification.getMessage())
         .createdAt(LocalDateTime.now())


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

#### LetterFacade
   - saveMenteeLetter 메서드의 반환 타입을 void에서 LetterStatusEntity로 변경하여 저장된 편지 상태를 반환하도록 수정.
   - letterStatusRepository.save()의 반환값을 직접 반환하여 이후 로직에서 활용 가능하도록 개선.

#### NotificationEntity
   - letterStatusSeq 필드를 추가하여 알림과 특정 편지를 연결할 수 있도록 변경.

#### NotificationDTO
   - NotificationDTO에서 thanksToMentor, sendLetter, replyLetter 등의 정적 메서드가 LetterStatusEntity를 직접 받도록 변경.
   - letterStatusSeq를 추가하여 편지 상태 정보를 포함하도록 개선.
   - of 메서드에서 NotificationEntity를 변환할 때 letterStatusSeq를 포함하도록 수정.
   - of 메서드에서 여러 개의 알림을 묶어서 보낼 때 사용하던 방식 제거.
   - toEntity 변환 로직에서도 letterStatusSeq를 포함하도록 수정.

#### LetterServiceImpl
   - sendLetter에서 saveMenteeLetter의 반환값을 LetterStatusEntity로 받아 활용하도록 변경.
   - redisTemplate.convertAndSend() 호출 시 NotificationDTO.sendLetter()에 LetterStatusEntity를 전달하도록 수정.
   - replyLetter에서 redisTemplate.convertAndSend() 호출 시 기존 mentor와 mentee 정보를 직접 전달하는 대신 LetterStatusEntity를 사용하도록 변경.
   - throwLetter에서 redisTemplate.convertAndSend() 호출 시 letterStatus.getMentee()와 newMentor를 직접 전달하는 방식에서 LetterStatusEntity를 사용하도록 개선.
   - thanksToMentor에서 redisTemplate.convertAndSend() 호출 시 NotificationDTO.thanksToMentor(letterStatus.getMentee(), letterStatus.getMentor()) 대신 NotificationDTO.thanksToMentor(letterStatus)를 사용하도록 수정.

#### NotificationServiceImpl
   - TIME_OUT 값을 30 * 60 * 1000L (30분)로 설정하여 SSE 연결 유지 시간을 관리하도록 변경.
   - SSE 구독 시 SseEmitter(Long.MAX_VALUE) 대신 TIME_OUT을 사용하여 관리하도록 개선.
   - sendPendingNotifications()에서 userSeq를 받던 방식을 UserEntity 객체를 받아 처리하도록 변경.
   - sendPendingNotifications() 내부에서 여러 개의 알림을 전송할 때 한 번에 전송하는 방식에서 개별적으로 전송하는 방식으로 변경.
   - sendNotification() 메서드에서 SSE 전송 시 notification.getMessage() 대신 전체 notification 객체를 전송하도록 수정.

## 스크린샷

## 주의사항

Closes #53 
