### PR TITLE
[feat] 관리자 기능 : 카테고리별 넘긴 편지 개수 확인 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -3,6 +3,7 @@ package com.enf.component.facade;
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.NotificationEntity;
+import com.enf.entity.ThrowLetterCategoryEntity;
 import com.enf.entity.ThrowLetterEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
@@ -10,11 +11,13 @@ import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
+import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
 import com.enf.repository.LetterRepository;
 import com.enf.repository.LetterStatusRepository;
 import com.enf.repository.NotificationRepository;
+import com.enf.repository.ThrowLetterCategoryRepository;
 import com.enf.repository.ThrowLetterRepository;
 import com.enf.repository.querydsl.LetterQueryRepository;
 import java.time.LocalDateTime;
@@ -33,6 +36,7 @@ public class LetterFacade {
   private final LetterStatusRepository letterStatusRepository;
   private final LetterQueryRepository letterQueryRepository;
   private final ThrowLetterRepository throwLetterRepository;
+  private final ThrowLetterCategoryRepository throwLetterCategoryRepository;
 
   /**
    * 특정 사용자의 모든 알림 조회
@@ -196,7 +200,13 @@ public class LetterFacade {
         .letterStatus(letterStatus)
         .throwUser(letterStatus.getMentor())
         .build();
+
     throwLetterRepository.save(throwLetterEntity);
+
+    letterQueryRepository.incrementCategory(
+        getThrowLetterCategory().getThrowLetterCategorySeq(),
+        letterStatus.getMenteeLetter().getCategoryName()
+    );
   }
 
   /**
@@ -221,5 +231,10 @@ public class LetterFacade {
     letterStatusRepository.updateIsThankToMentor(letterStatus.getLetterStatusSeq());
 
     return letterStatus;
+  }
+
+  public ThrowLetterCategoryEntity getThrowLetterCategory() {
+    return throwLetterCategoryRepository.findByThrowLetterCategorySeq(1L)
+        .orElseGet(() -> throwLetterCategoryRepository.save(ThrowLetterCategoryDTO.create()));
   }
 }

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -159,4 +159,11 @@ public class LetterController {
     ResultResponse response = letterService.thanksToMentor(request, letterSeq);
     return new ResponseEntity<>(response, response.getStatus());
   }
+
+  @GetMapping("/throws/category")
+  public ResponseEntity<ResultResponse> getThrowLetterCategory(HttpServletRequest request) {
+
+    ResultResponse response = letterService.getThrowLetterCategory(request);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
 }

--- a/EnF/src/main/java/com/enf/entity/ThrowLetterCategoryEntity.java
+++ b/EnF/src/main/java/com/enf/entity/ThrowLetterCategoryEntity.java
@@ -1,0 +1,39 @@
+package com.enf.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "throw_letter_category")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ThrowLetterCategoryEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long throwLetterCategorySeq;
+
+  private Long career;           // 커리어
+
+  private Long mental;           // 마음건강
+
+  private Long relationship;     // 대인관계
+
+  private Long love;             // 사랑
+
+  private Long life;             // 삶의 방향/가치관
+
+  private Long finance;          // 자산관리
+
+  private Long housing;          // 주거/독립
+
+  private Long other;            // 기타
+
+}

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/ThrowLetterCategoryDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/ThrowLetterCategoryDTO.java
@@ -1,0 +1,56 @@
+package com.enf.model.dto.response.letter;
+
+import com.enf.entity.ThrowLetterCategoryEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ThrowLetterCategoryDTO {
+
+  private Long career;           // 커리어
+
+  private Long mental;           // 마음건강
+
+  private Long relationship;     // 대인관계
+
+  private Long love;             // 사랑
+
+  private Long life;             // 삶의 방향/가치관
+
+  private Long finance;          // 자산관리
+
+  private Long housing;          // 주거/독립
+
+  private Long other;            // 기타
+
+
+  public static ThrowLetterCategoryEntity create() {
+    return ThrowLetterCategoryEntity.builder()
+        .career(0L)
+        .mental(0L)
+        .relationship(0L)
+        .love(0L)
+        .life(0L)
+        .finance(0L)
+        .housing(0L)
+        .other(0L)
+        .build();
+  }
+
+  public static ThrowLetterCategoryDTO of(ThrowLetterCategoryEntity throwLetterCategoryEntity) {
+    return new ThrowLetterCategoryDTO(
+        throwLetterCategoryEntity.getCareer(),
+        throwLetterCategoryEntity.getMental(),
+        throwLetterCategoryEntity.getRelationship(),
+        throwLetterCategoryEntity.getLove(),
+        throwLetterCategoryEntity.getLife(),
+        throwLetterCategoryEntity.getFinance(),
+        throwLetterCategoryEntity.getHousing(),
+        throwLetterCategoryEntity.getOther()
+    );
+  }
+
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -24,6 +24,7 @@ public enum SuccessResultType {
   SUCCESS_GET_LETTER_DETAILS(HttpStatus.OK, "편지 상세 조회 성공"),
   SUCCESS_THROW_LETTER(HttpStatus.OK, "편지 넘기기 성공"),
   SUCCESS_THANKS_TO_MENTOR(HttpStatus.OK, "고마움 표시하기 성공"),
+  SUCCESS_GET_THROW_LETTER_CATEGORY(HttpStatus.OK, "카테고리별 넘긴 편지 개수 조회 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/ThrowLetterCategoryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/ThrowLetterCategoryRepository.java
@@ -1,0 +1,15 @@
+package com.enf.repository;
+
+import com.enf.entity.ThrowLetterCategoryEntity;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ThrowLetterCategoryRepository extends JpaRepository<ThrowLetterCategoryEntity, Long> {
+  Optional<ThrowLetterCategoryEntity> findByThrowLetterCategorySeq(Long seq);
+
+}

--- a/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
+++ b/EnF/src/main/java/com/enf/repository/querydsl/LetterQueryRepository.java
@@ -1,12 +1,18 @@
 package com.enf.repository.querydsl;
 
+import static com.enf.entity.QThrowLetterCategoryEntity.throwLetterCategoryEntity;
+
 import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.QLetterStatusEntity;
+import com.enf.entity.QThrowLetterCategoryEntity;
+import com.enf.entity.ThrowLetterCategoryEntity;
 import com.enf.entity.UserEntity;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +26,7 @@ public class LetterQueryRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
   QLetterStatusEntity letterStatus = QLetterStatusEntity.letterStatusEntity;
+  QThrowLetterCategoryEntity letterCategory = throwLetterCategoryEntity;
 
   /**
    * 멘티 또는 멘토의 편지 목록 조회 (페이징 지원)
@@ -70,6 +77,31 @@ public class LetterQueryRepository {
 
     // 페이징 처리 후 반환
     return PageResponse.pagination(receiveLetters, pageNumber);
+  }
+
+  @Transactional
+  public void incrementCategory(Long letterCategorySeq, String categoryName) {
+    NumberPath<Long> categoryField = getCategoryField(categoryName);
+
+    jpaQueryFactory
+        .update(throwLetterCategoryEntity)
+        .set(categoryField, categoryField.add(1))
+        .where(throwLetterCategoryEntity.throwLetterCategorySeq.eq(letterCategorySeq))
+        .execute();
+  }
+
+  private NumberPath<Long> getCategoryField(String categoryName) {
+    return switch (categoryName) {
+      case "career" -> throwLetterCategoryEntity.career;
+      case "mental" -> throwLetterCategoryEntity.mental;
+      case "relationship" -> throwLetterCategoryEntity.relationship;
+      case "love" -> throwLetterCategoryEntity.love;
+      case "life" -> throwLetterCategoryEntity.life;
+      case "finance" -> throwLetterCategoryEntity.finance;
+      case "housing" -> throwLetterCategoryEntity.housing;
+      case "other" -> throwLetterCategoryEntity.other;
+      default -> throw new IllegalArgumentException("Invalid category name: " + categoryName);
+    };
   }
 
 }

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -24,4 +24,6 @@ public interface LetterService {
   ResultResponse throwLetter(HttpServletRequest request, Long letterStatusSeq);
 
   ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq);
+
+  ResultResponse getThrowLetterCategory(HttpServletRequest request);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -12,6 +12,7 @@ import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
+import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
 import com.enf.model.type.SuccessResultType;
@@ -224,5 +225,13 @@ public class LetterServiceImpl implements LetterService {
     redisTemplate.convertAndSend("notifications", NotificationDTO.thanksToMentor(letterStatus));
 
     return ResultResponse.of(SuccessResultType.SUCCESS_THANKS_TO_MENTOR);
+  }
+
+  @Override
+  public ResultResponse getThrowLetterCategory(HttpServletRequest request) {
+    ThrowLetterCategoryDTO throwLetterCategory = ThrowLetterCategoryDTO
+        .of(letterFacade.getThrowLetterCategory());
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_THROW_LETTER_CATEGORY, throwLetterCategory);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
관리자 기능

- 수정
   - 멘토가 편지를 넘길 경우 넘긴 편지의 카테고리를 count 하는 로직추가
- 관리자 기능
   - 카테고리별 넘긴 편지 개수를 확인 할 수 있는 API 구현

## 스크린샷

## 주의사항

Closes #55 
