### PR TITLE
[feat] 전반적인 리페토링

### DIFF
--- a/EnF/src/main/java/com/enf/EnFApplication.java
+++ b/EnF/src/main/java/com/enf/EnFApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 public class EnFApplication {
 
   public static void main(String[] args) {

--- a/EnF/src/main/java/com/enf/component/KakaoAuthHandler.java
+++ b/EnF/src/main/java/com/enf/component/KakaoAuthHandler.java
@@ -1,6 +1,7 @@
 package com.enf.component;
 
 
+import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.auth.KakaoUserDetailsDTO;
 import com.enf.model.type.FailedResultType;
@@ -107,4 +108,38 @@ public class KakaoAuthHandler {
     throw new GlobalException(FailedResultType.USER_INFO_RETRIEVAL);
   }
 
+  // 카카오 사용자 Unlink
+  public void unlinkUser(UserEntity user) {
+    // HTTP 헤더 설정
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "KakaoAK " + adminKey);
+    headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+    // 요청 바디 설정
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("target_id_type", "user_id");
+    body.add("target_id", user.getProviderId());
+
+    // HTTP 요청 객체 생성
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+    // RestTemplate 초기화
+    RestTemplate restTemplate = new RestTemplate();
+
+    // 요청 전송
+    ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+        UrlType.KAKAO_UNLINK_URL.getUrl(),
+        HttpMethod.POST,
+        request,
+        new ParameterizedTypeReference<>() {}
+    );
+
+    // 응답 처리
+    if (response.getStatusCode() == HttpStatus.OK) {
+      log.info("회원 탈퇴 성공: {}", user.getNickname());
+    } else {
+      log.error("회원 탈퇴 실패: {}", response.getStatusCode());
+      throw new GlobalException(FailedResultType.UNLINK_FAILED);
+    }
+  }
 }

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -1,11 +1,6 @@
 package com.enf.component.facade;
 
-import com.enf.entity.LetterEntity;
-import com.enf.entity.LetterStatusEntity;
-import com.enf.entity.NotificationEntity;
-import com.enf.entity.ThrowLetterCategoryEntity;
-import com.enf.entity.ThrowLetterEntity;
-import com.enf.entity.UserEntity;
+import com.enf.entity.*;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.response.PageResponse;
@@ -14,17 +9,12 @@ import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
-import com.enf.repository.LetterRepository;
-import com.enf.repository.LetterStatusRepository;
-import com.enf.repository.NotificationRepository;
-import com.enf.repository.ThrowLetterCategoryRepository;
-import com.enf.repository.ThrowLetterRepository;
+import com.enf.repository.*;
 import com.enf.repository.querydsl.LetterQueryRepository;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -37,6 +27,7 @@ public class LetterFacade {
   private final LetterQueryRepository letterQueryRepository;
   private final ThrowLetterRepository throwLetterRepository;
   private final ThrowLetterCategoryRepository throwLetterCategoryRepository;
+  private final UserFacade userFacade;
 
   /**
    * 특정 사용자의 모든 알림 조회
@@ -72,25 +63,11 @@ public class LetterFacade {
    * @param letter 저장할 편지 엔티티
    * @param mentee 편지를 보낸 멘티
    * @param mentor 편지를 받는 멘토
+   * @return 저장된 LetterStatusEntity 객체
    */
   public LetterStatusEntity saveMenteeLetter(LetterEntity letter, UserEntity mentee, UserEntity mentor) {
-    // 편지를 저장
-    LetterEntity menteeLetter = letterRepository.save(letter);
-
-    // 편지 상태 저장 (멘토가 답장할 때 참조할 수 있도록 함)
-    return letterStatusRepository.save(
-        LetterStatusEntity.builder()
-            .mentee(mentee)
-            .mentor(mentor)
-            .menteeLetter(menteeLetter)
-            .isMenteeRead(false)
-            .isMentorRead(false)
-            .isMenteeSaved(false)
-            .isMentorSaved(false)
-            .isThanksToMentor(false)
-            .createAt(LocalDateTime.now())
-            .build()
-    );
+    userFacade.reduceQuota(mentee);
+    return letterStatusRepository.save(LetterStatusEntity.of(letterRepository.save(letter), mentee, mentor));
   }
 
   /**
@@ -100,48 +77,31 @@ public class LetterFacade {
    * @param replyLetter 멘티가 보낸 원본 편지 엔티티
    */
   public void saveMentorLetter(LetterStatusEntity letterStatus, ReplyLetterDTO replyLetter) {
-    LetterEntity letter = ReplyLetterDTO
-        .of(replyLetter, letterStatus.getMenteeLetter().getCategoryName());
-    // 멘토의 답장 편지를 저장
-    LetterEntity mentorLetter = letterRepository.save(letter);
-
-    // 기존 편지 상태 업데이트 (멘토의 답장을 반영)
+    userFacade.reduceQuota(letterStatus.getMentor());
+    LetterEntity mentorLetter = letterRepository.save(ReplyLetterDTO.of(replyLetter, letterStatus.getMenteeLetter().getCategoryName()));
     letterStatusRepository.updateLetterStatus(letterStatus.getLetterStatusSeq(), mentorLetter);
   }
 
   /**
    * 특정 사용자의 모든 편지를 조회하는 기능 (멘티와 멘토 구분하여 처리)
    *
-   * 1. 사용자 정보를 기반으로 해당 사용자가 보낸 또는 받은 편지를 조회한다.
-   * 2. LetterListType을 활용하여 전체, 미응답, 저장된 편지 유형을 필터링할 수 있다.
-   * 3. QueryDSL 기반의 `letterQueryRepository`를 통해 데이터 조회 후 페이징 처리한다.
-   *
-   * @param user        현재 로그인한 사용자 (멘티 또는 멘토)
-   * @param pageNumber  요청한 페이지 번호
+   * @param user 현재 로그인한 사용자 (멘티 또는 멘토)
+   * @param pageNumber 요청한 페이지 번호
    * @param letterListType 조회할 편지 유형 (ALL, PENDING, SAVE)
    * @return 페이지네이션이 적용된 편지 목록
    */
-  public PageResponse<ReceiveLetterDTO> getLetterList(UserEntity user,
-      int pageNumber, LetterListType letterListType) {
-
+  public PageResponse<ReceiveLetterDTO> getLetterList(UserEntity user, int pageNumber, LetterListType letterListType) {
     return letterQueryRepository.getLetterList(user, pageNumber, letterListType.getValue());
   }
 
   /**
    * 특정 사용자가 편지를 저장하는 기능
    *
-   * 1. 사용자의 역할(멘티 또는 멘토)을 확인하여 적절한 저장 로직을 실행한다.
-   * 2. 멘티라면 `saveLetterForMentee()` 메서드를 호출하여 저장 처리한다.
-   * 3. 멘토라면 `saveLetterForMentor()` 메서드를 호출하여 저장 처리한다.
-   * 4. 해당 편지가 성공적으로 저장되었음을 나타내는 응답을 반환한다.
-   *
-   * @param user      현재 로그인한 사용자 (멘티 또는 멘토)
+   * @param user 현재 로그인한 사용자 (멘티 또는 멘토)
    * @param letterStatusSeq 저장할 편지의 고유 식별자 (ID)
    */
   public void saveLetter(UserEntity user, Long letterStatusSeq) {
-    boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
-
-    if (isMentee) {
+    if (user.getRole().getRoleName().equals("MENTEE")) {
       letterStatusRepository.saveLetterForMentee(letterStatusSeq);
     } else {
       letterStatusRepository.saveLetterForMentor(letterStatusSeq);
@@ -153,60 +113,48 @@ public class LetterFacade {
    *
    * @param letterStatusSeq 편지 상태 ID
    * @return 조회된 LetterStatusEntity 객체
-   * @throws GlobalException 편지가 존재하지 않을 경우 예외 발생
    */
   public LetterStatusEntity getLetterStatus(Long letterStatusSeq) {
-    return letterStatusRepository
-        .findLetterStatusByLetterStatusSeq(letterStatusSeq)
+    return letterStatusRepository.findLetterStatusByLetterStatusSeq(letterStatusSeq)
         .orElseThrow(() -> new GlobalException(FailedResultType.LETTER_NOT_FOUND));
   }
 
   /**
    * 편지 상세 정보 조회 메서드
    *
-   * 사용자의 역할(멘티/멘토)에 따라 다른 DTO 변환 로직 수행
-   *
-   * @param user      요청한 사용자 (멘티 또는 멘토)
+   * @param user 요청한 사용자 (멘티 또는 멘토)
    * @param letterStatus 조회할 편지
    * @return 편지 상세 정보를 포함하는 LetterDetailsDTO
-   * @throws GlobalException 편지를 찾을 수 없는 경우 LETTER_NOT_FOUND 예외 발생
    */
   public LetterDetailsDTO getLetterDetails(UserEntity user, LetterStatusEntity letterStatus) {
-
-    boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
-
-    if (isMentee) {
+    if (user.getRole().getRoleName().equals("MENTEE")) {
       if (!letterStatus.isMenteeRead()) {
         letterStatusRepository.updateIsMenteeRead(letterStatus.getLetterStatusSeq());
       }
+      return LetterDetailsDTO.ofMentee(letterStatus);
     } else {
       if (!letterStatus.isMentorRead()) {
         letterStatusRepository.updateIsMentorRead(letterStatus.getLetterStatusSeq());
       }
+      return LetterDetailsDTO.ofMentor(letterStatus);
     }
-
-    return user.getRole().getRoleName().equals("MENTEE")
-        ? LetterDetailsDTO.ofMentee(letterStatus)
-        : LetterDetailsDTO.ofMentor(letterStatus);
   }
 
   /**
    * 편지를 새로운 멘토에게 전달하는 메서드
    *
-   * @param letterStatus  현재 편지의 상태 정보
+   * @param letterStatus 현재 편지의 상태 정보
    */
   public void throwLetter(LetterStatusEntity letterStatus) {
-    ThrowLetterEntity throwLetterEntity = ThrowLetterEntity.builder()
-        .letterStatus(letterStatus)
-        .throwUser(letterStatus.getMentor())
-        .build();
-
-    throwLetterRepository.save(throwLetterEntity);
+    throwLetterRepository.save(
+        ThrowLetterEntity.builder()
+            .letterStatus(letterStatus)
+            .throwUser(letterStatus.getMentor())
+            .build());
 
     letterQueryRepository.incrementCategory(
         getThrowLetterCategory().getThrowLetterCategorySeq(),
-        letterStatus.getMenteeLetter().getCategoryName()
-    );
+        letterStatus.getMenteeLetter().getCategoryName());
   }
 
   /**
@@ -225,14 +173,16 @@ public class LetterFacade {
    * @param letterSeq 고마움을 전달할 멘토 편지의 고유 식별자
    */
   public LetterStatusEntity thanksToMentor(Long letterSeq) {
-    LetterStatusEntity letterStatus = letterStatusRepository
-        .getLetterStatusByMentorLetterLetterSeq(letterSeq);
-
+    LetterStatusEntity letterStatus = letterStatusRepository.getLetterStatusByMentorLetterLetterSeq(letterSeq);
     letterStatusRepository.updateIsThankToMentor(letterStatus.getLetterStatusSeq());
-
     return letterStatus;
   }
 
+  /**
+   * 편지 카테고리 정보를 조회하는 메서드
+   *
+   * @return ThrowLetterCategoryEntity 객체
+   */
   public ThrowLetterCategoryEntity getThrowLetterCategory() {
     return throwLetterCategoryRepository.findByThrowLetterCategorySeq(1L)
         .orElseGet(() -> throwLetterCategoryRepository.save(ThrowLetterCategoryDTO.create()));

--- a/EnF/src/main/java/com/enf/config/SchedulerConfiguration.java
+++ b/EnF/src/main/java/com/enf/config/SchedulerConfiguration.java
@@ -1,0 +1,37 @@
+package com.enf.config;
+
+import com.enf.component.facade.UserFacade;
+import com.enf.entity.QuotaEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SchedulerConfiguration {
+
+  private final UserFacade userFacade;
+
+
+  @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul") // 매주 월요일 00:00 실행 (한국 시간 기준)
+  public void updateLetterQuota() {
+    log.info("사용자 편지 할당량 초기화 작업 시작");
+
+    List<QuotaEntity> quotas = userFacade.getQuotas();
+    if (quotas == null || quotas.isEmpty()) {
+      log.info("초기화할 사용자 할당량이 없음");
+      return;
+    }
+
+    for (QuotaEntity quota : quotas) {
+      boolean isMentee = quota.getUser().getRole().getRoleName().equals("MENTEE");
+      userFacade.resetQuota(quota.getUser(), isMentee ? 4 : 7);
+    }
+
+    log.info("사용자 편지 할당량 초기화 작업 완료");
+  }
+
+}

--- a/EnF/src/main/java/com/enf/config/SecurityConfig.java
+++ b/EnF/src/main/java/com/enf/config/SecurityConfig.java
@@ -37,10 +37,11 @@ public class SecurityConfig {
                 .sessionManagement(session->session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(                         // 경로별 인가 설정
                 authorizeRequests -> authorizeRequests
-                                .requestMatchers(SecurityConstants.swaggerUrls).permitAll()
                                 .requestMatchers(SecurityConstants.allowedUrls).permitAll()  // 허용 URL 설정
                                 .requestMatchers(SecurityConstants.adminUrls).hasAnyAuthority("ADMIN","DEVELOPER") // 관리자만 접근 가능
-                                .requestMatchers(SecurityConstants.userUrls).hasAnyAuthority("UNKNOWN","MENTEE","MENTOR","ADMIN","DEVELOPER") // 주니어 사용자 접근 가능
+                                .requestMatchers(SecurityConstants.userUrls).hasAnyAuthority("UNKNOWN","MENTEE","MENTOR","ADMIN","DEVELOPER") // 사용자 접근 가능
+                                .requestMatchers(SecurityConstants.menteeUrls).hasAnyAuthority("MENTEE", "ADMIN","DEVELOPER")
+                                .requestMatchers(SecurityConstants.mentorUrls).hasAnyAuthority("MENTOR", "ADMIN","DEVELOPER")
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtTokenFilter(tokenProvider,jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/EnF/src/main/java/com/enf/config/SecurityConstants.java
+++ b/EnF/src/main/java/com/enf/config/SecurityConstants.java
@@ -8,9 +8,9 @@ public class SecurityConstants {
     public static final String[] swaggerUrls = {"/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**"};
     //인증 없이 허용할 경로 리스트
     public static final String[] allowUrls = {
-            "/api/v1/auth/callback",    // kakao sns login redirect url
-            "/api/v1/auth/kakao",
-            "/api/v1/auth/reissue-token",
+        "/api/v1/auth/callback",    // kakao sns login redirect url
+        "/api/v1/auth/kakao",
+        "/api/v1/auth/reissue-token",
 
     };
 
@@ -19,9 +19,27 @@ public class SecurityConstants {
     };
 
     public static final String[] userUrls = {
-            "/api/v1/user/check-nickname",
-            "/api/v1/user/additional-info",
-            "/api/v1/letter/send",
+        "/api/v1/user/check-nickname",
+        "/api/v1/user/additional-info",
+        "/api/v1/user/info",
+        "/api/v1/user/update/nickname",
+        "/api/v1/letter/list/save",
+        "/api/v1/letter/list/pending",
+        "/api/v1/letter/list/all",
+        "/api/v1/letter/details",
+        "/api/v1/notification/subscribe",
+    };
+
+    public static final String[] menteeUrls = {
+        "/api/v1/letter/send",
+        "/api/v1/letter/thanks",
+        "/api/v1/letter/save",
+    };
+
+    public static final String[] mentorUrls = {
+        "/api/v1/user/update/category",
+        "/api/v1/letter/reply",
+        "/api/v1/letter/throw",
     };
 
     // 허용 Urls

--- a/EnF/src/main/java/com/enf/controller/AuthController.java
+++ b/EnF/src/main/java/com/enf/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -63,6 +64,13 @@ public class AuthController {
       HttpServletResponse response) {
 
     ResultResponse resultResponse = authService.reissueToken(request, response);
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+
+  @GetMapping("/withdrawal")
+  public ResponseEntity<ResultResponse> withdrawal(HttpServletRequest request) {
+
+    ResultResponse resultResponse = authService.withdrawal(request);
     return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 }

--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -56,4 +56,18 @@ public class LetterStatusEntity {
   private boolean isThanksToMentor;
 
   private LocalDateTime createAt;
+
+  public static LetterStatusEntity of(LetterEntity menteeLetter, UserEntity mentee, UserEntity mentor) {
+    return LetterStatusEntity.builder()
+        .mentee(mentee)
+        .mentor(mentor)
+        .menteeLetter(menteeLetter)
+        .isMenteeRead(false)
+        .isMentorRead(false)
+        .isMenteeSaved(false)
+        .isMentorSaved(false)
+        .isThanksToMentor(false)
+        .createAt(LocalDateTime.now())
+        .build();
+  }
 }

--- a/EnF/src/main/java/com/enf/entity/UserEntity.java
+++ b/EnF/src/main/java/com/enf/entity/UserEntity.java
@@ -47,6 +47,8 @@ public class UserEntity {
 
   private LocalDateTime lastLoginAt;
 
+  private LocalDateTime deleteAt;
+
   private String refreshToken;
 
 }

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -19,6 +19,7 @@ public enum FailedResultType {
   MENTEE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "멘티는 접근 권한이 없습니다."),
   MENTOR_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "멘토는 접근 권한이 없습니다."),
   ALREADY_REPLIED(HttpStatus.BAD_REQUEST, "이미 답장한 편지는 넘길 수 없습니다."),
+  UNLINK_FAILED(HttpStatus.BAD_REQUEST, "회원탈퇴 실패 했습니다")
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -25,6 +25,7 @@ public enum SuccessResultType {
   SUCCESS_THROW_LETTER(HttpStatus.OK, "편지 넘기기 성공"),
   SUCCESS_THANKS_TO_MENTOR(HttpStatus.OK, "고마움 표시하기 성공"),
   SUCCESS_GET_THROW_LETTER_CATEGORY(HttpStatus.OK, "카테고리별 넘긴 편지 개수 조회 성공"),
+  SUCCESS_KAKAO_WITHDRAWAL(HttpStatus.OK, "회원탈퇴 성공"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/model/type/UrlType.java
+++ b/EnF/src/main/java/com/enf/model/type/UrlType.java
@@ -7,6 +7,7 @@ public enum UrlType {
 
   KAKAO_TOKEN_URL("https://kauth.kakao.com/oauth/token"),
   KAKAO_USER_INFO_URL("https://kapi.kakao.com/v2/user/me"),
+  KAKAO_UNLINK_URL("https://kapi.kakao.com/v1/user/unlink"),
   FRONT_LOCAL_URL("http://localhost:3000"),
   ;
 

--- a/EnF/src/main/java/com/enf/repository/QuotaRepository.java
+++ b/EnF/src/main/java/com/enf/repository/QuotaRepository.java
@@ -1,10 +1,26 @@
 package com.enf.repository;
 
 import com.enf.entity.QuotaEntity;
+import com.enf.entity.UserEntity;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface QuotaRepository extends JpaRepository<QuotaEntity, Long> {
 
+  @Modifying
+  @Transactional
+  @Query("UPDATE quota q SET quota = :quota WHERE q.user = :user")
+  void updateQuota(@Param("user") UserEntity user, @Param("quota") int quota);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE quota q "
+      + "SET q.quota = CASE WHEN q.quota > 0 THEN q.quota - 1 ELSE q.quota END "
+      + "WHERE q.user = :user")
+  void reduceQuota(@Param("user") UserEntity user);
 }

--- a/EnF/src/main/java/com/enf/repository/UserRepository.java
+++ b/EnF/src/main/java/com/enf/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.enf.repository;
 
 import com.enf.entity.CategoryEntity;
+import com.enf.entity.RoleEntity;
 import com.enf.entity.UserEntity;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
@@ -43,7 +44,9 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   @Query("UPDATE user u set u.category = :category WHERE u.userSeq = :userSeq")
   void updateCategoryByUserSeq(Long userSeq, CategoryEntity category);
 
-  Optional<UserEntity> findByNickname(String nickname);
 
-
+  @Modifying
+  @Transactional
+  @Query("UPDATE user u set u.deleteAt = CURRENT_TIMESTAMP, u.role = :role WHERE u.userSeq = :userSeq")
+  void pendingWithdrawal(Long userSeq, RoleEntity role);
 }

--- a/EnF/src/main/java/com/enf/service/AuthService.java
+++ b/EnF/src/main/java/com/enf/service/AuthService.java
@@ -14,4 +14,6 @@ public interface AuthService {
   UserDetails loadUserById(Long userSeq) throws UsernameNotFoundException;
 
   ResultResponse reissueToken(HttpServletRequest request, HttpServletResponse response);
+
+  ResultResponse withdrawal(HttpServletRequest request);
 }

--- a/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/AuthServiceImpl.java
@@ -107,6 +107,20 @@ public class AuthServiceImpl implements AuthService {
   }
 
   /**
+   * 회원 탈퇴 처리하는 메서드
+   *
+   * @param request  HTTP 요청 객체
+   * @return 회원탈퇴 결과 응답 객체
+   */
+  @Override
+  public ResultResponse withdrawal(HttpServletRequest request) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+    userFacade.pendingWithdrawal(user);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_KAKAO_WITHDRAWAL);
+  }
+
+  /**
    * 쿠키에서 Refresh Token을 추출하는 메서드
    *
    * @param cookies HTTP 요청에서 전달된 쿠키 배열


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
   - 기능 추가
      - 회원 탈퇴 보류 기능 추가
      - UserEntity에 deleteAt 필드 추가.
      - UserRepository에 회원 탈퇴 보류 처리(pendingWithdrawal)를 위한 쿼리 추가.
      - UserFacade에 pendingWithdrawal 메서드 추가.
      - AuthService 및 AuthServiceImpl에 withdrawal 메서드 추가.
      - AuthController에 /withdrawal 엔드포인트 추가.
      - 카카오 사용자 Unlink(탈퇴) 기능 추가
      - KakaoAuthHandler에 unlinkUser 메서드 추가 (카카오 사용자 연결 해제).
      - 사용자 편지 할당량 초기화 스케줄링 추가
      - SchedulerConfiguration 클래스 추가.
      - 매주 월요일 00:00에 QuotaEntity의 할당량 초기화 (MENTEE 4개, MENTOR 7개).

   - 기능 수정 및 최적화
      - 편지 관련 로직 최적화
      - LetterFacade 및 LetterServiceImpl에서 userFacade.reduceQuota(user) 추가하여 편지 전송 시 사용자의 할당량 감소 처리.
      - saveMenteeLetter, saveMentorLetter의 로직을 정리하여 중복 코드 제거.
      - 권한 검사 방식 개선
      - SecurityConfig에서 SecurityConstants의 URL 리스트를 활용하여 경로별 권한 제어.
      - SecurityConstants에 swaggerUrls, allowUrls, userUrls, menteeUrls, mentorUrls 정리 및 추가.
      - QueryDSL을 활용한 mentor 조회 개선
      - getMentorByBirdAndCategory 및 getNewMentor의 UserQueryRepository 활용 방식 개선.

   - 데이터베이스 변경
      - UserEntity 필드 추가
      - deleteAt (회원 탈퇴 시각 저장).
      - refreshToken (토큰 재발급을 위한 필드).
      - 쿼리 수정 및 추가
      - QuotaRepository에 updateQuota, reduceQuota 추가.
      - UserRepository에 pendingWithdrawal 추가.

   - 예외 처리 개선
      - FailedResultType에 UNLINK_FAILED (회원 탈퇴 실패) 추가.
      - SuccessResultType에 SUCCESS_KAKAO_WITHDRAWAL (카카오 회원 탈퇴 성공) 추가.

   - 기타 코드 리팩토링
      - import 정리 (LetterFacade, UserFacade 등).
      - 불필요한 변수 제거 및 Optional 활용 최적화.
      - LetterStatusEntity의 of 정적 팩토리 메서드 추가 (객체 생성 방식 통일).
     
## 스크린샷

## 주의사항

Closes #57 
