### PR TITLE
[refactor] 편지 고마움 전달 API 로직 수정

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -14,6 +14,7 @@ import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
 import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
+import com.enf.model.type.ThanksType;
 import com.enf.repository.LetterRepository;
 import com.enf.repository.LetterStatusRepository;
 import com.enf.repository.NotificationRepository;
@@ -181,9 +182,10 @@ public class LetterFacade {
    *
    * @param letterSeq 고마움을 전달할 멘토 편지의 고유 식별자
    */
-  public LetterStatusEntity thanksToMentor(Long letterSeq) {
+  public LetterStatusEntity thanksToMentor(Long letterSeq, String tyoe) {
+    ThanksType thanksType = ThanksType.valueOf(tyoe);
     LetterStatusEntity letterStatus = letterStatusRepository.getLetterStatusByMentorLetterLetterSeq(letterSeq);
-    letterStatusRepository.thankToMentor(letterStatus.getLetterStatusSeq());
+    letterStatusRepository.thankToMentor(letterStatus.getLetterStatusSeq(), thanksType);
     return letterStatus;
   }
 

--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -182,8 +182,8 @@ public class LetterFacade {
    *
    * @param letterSeq 고마움을 전달할 멘토 편지의 고유 식별자
    */
-  public LetterStatusEntity thanksToMentor(Long letterSeq, String tyoe) {
-    ThanksType thanksType = ThanksType.valueOf(tyoe);
+  public LetterStatusEntity thanksToMentor(Long letterSeq, String type) {
+    ThanksType thanksType = ThanksType.valueOf(type);
     LetterStatusEntity letterStatus = letterStatusRepository.getLetterStatusByMentorLetterLetterSeq(letterSeq);
     letterStatusRepository.thankToMentor(letterStatus.getLetterStatusSeq(), thanksType);
     return letterStatus;

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -154,9 +154,9 @@ public class LetterController {
    */
   @GetMapping("/thanks")
   public ResponseEntity<ResultResponse> thanksToMentor(HttpServletRequest request,
-      @RequestParam(name = "letterSeq") Long letterSeq, String tyoe) {
+      @RequestParam(name = "letterSeq") Long letterSeq, String type) {
 
-    ResultResponse response = letterService.thanksToMentor(request, letterSeq, tyoe);
+    ResultResponse response = letterService.thanksToMentor(request, letterSeq, type);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -154,9 +154,9 @@ public class LetterController {
    */
   @GetMapping("/thanks")
   public ResponseEntity<ResultResponse> thanksToMentor(HttpServletRequest request,
-      @RequestParam(name = "letterSeq") Long letterSeq) {
+      @RequestParam(name = "letterSeq") Long letterSeq, String tyoe) {
 
-    ResultResponse response = letterService.thanksToMentor(request, letterSeq);
+    ResultResponse response = letterService.thanksToMentor(request, letterSeq, tyoe);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -1,7 +1,10 @@
 package com.enf.entity;
 
+import com.enf.model.type.ThanksType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -53,8 +56,9 @@ public class LetterStatusEntity {
     @Column(name = "is_mentor_saved")
     private boolean isMentorSaved = false;  // 기본값 설정
 
-    @Column(name = "is_thanks_to_mentor")
-    private boolean isThanksToMentor;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "thanks_type")
+    private ThanksType thanksType;
 
     private LocalDateTime createAt;
 
@@ -67,7 +71,7 @@ public class LetterStatusEntity {
           .isMentorRead(false)
           .isMenteeSaved(false)
           .isMentorSaved(false)
-          .isThanksToMentor(false)
+          .thanksType(null)
           .createAt(LocalDateTime.now())
           .build();
     }

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/LetterDetailsDTO.java
@@ -16,13 +16,15 @@ public class LetterDetailsDTO {
 
   private boolean saved;
 
+  private String thanksToMentor;
+
   public static LetterDetailsDTO ofMentee(LetterStatusEntity letterStatus) {
     LetterDTO replyLetter;
     LetterDTO sendLetter;
 
     if (letterStatus.getMentorLetter() == null) {
       sendLetter = LetterDTO.of(null, letterStatus.getMentee(), letterStatus.getMenteeLetter());
-      return new LetterDetailsDTO(null, sendLetter, letterStatus.isMenteeSaved());
+      return new LetterDetailsDTO(null, sendLetter, letterStatus.isMenteeSaved(), letterStatus.getThanksType().getText());
     }
 
     replyLetter = LetterDTO.of(
@@ -35,7 +37,7 @@ public class LetterDetailsDTO {
         letterStatus.getMentee(),
         letterStatus.getMenteeLetter());
 
-    return new LetterDetailsDTO(replyLetter, sendLetter, letterStatus.isMenteeSaved());
+    return new LetterDetailsDTO(replyLetter, sendLetter, letterStatus.isMenteeSaved(), letterStatus.getThanksType().getText());
   }
 
   public static LetterDetailsDTO ofMentor(LetterStatusEntity letterStatus) {
@@ -47,7 +49,7 @@ public class LetterDetailsDTO {
     );
 
     if (letterStatus.getMentorLetter() == null) {
-      return new LetterDetailsDTO(replyLetter, null, letterStatus.isMentorSaved());
+      return new LetterDetailsDTO(replyLetter, null, letterStatus.isMentorSaved(), letterStatus.getThanksType().getText());
     }
 
     LetterDTO sendLetter = LetterDTO.of(
@@ -56,6 +58,6 @@ public class LetterDetailsDTO {
         letterStatus.getMentorLetter()
     );
 
-    return new LetterDetailsDTO(replyLetter, sendLetter, letterStatus.isMentorSaved());
+    return new LetterDetailsDTO(replyLetter, sendLetter, letterStatus.isMentorSaved(), letterStatus.getThanksType().getText());
   }
 }

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/ReceiveLetterDTO.java
@@ -23,6 +23,7 @@ public class ReceiveLetterDTO {
 
   private boolean saved;
 
+  private boolean thanksToMentor;
 
   public static List<ReceiveLetterDTO> ofMentee(List<LetterStatusEntity> list) {
     return list.stream()
@@ -36,7 +37,8 @@ public class ReceiveLetterDTO {
                   ? letterStatus.getMenteeLetter().getLetterTitle()
                   : letterStatus.getMentorLetter().getLetterTitle(),
               letterStatus.isMenteeRead(),
-              letterStatus.isMenteeSaved()
+              letterStatus.isMenteeSaved(),
+              letterStatus.getThanksType() != null
           );
         })
         .toList();
@@ -51,7 +53,8 @@ public class ReceiveLetterDTO {
                 letterStatus.getMentee().getNickname(),
                 letterStatus.getMenteeLetter().getLetterTitle(),
                 letterStatus.isMentorRead(),
-                letterStatus.isMentorSaved()
+                letterStatus.isMentorSaved(),
+                letterStatus.getThanksType() != null
             )
         )
         .toList();

--- a/EnF/src/main/java/com/enf/model/type/ThanksType.java
+++ b/EnF/src/main/java/com/enf/model/type/ThanksType.java
@@ -1,0 +1,17 @@
+package com.enf.model.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ThanksType {
+
+  MOVED("정성어린 답장에 감동 받았어요!"),
+  HELPFUL("편지 내용이 도움이 되었어요!"),
+  NOT_ALONE("혼자가 아닌 것 같아 기뻐요!");
+
+  private final String text;
+
+  ThanksType(String value) {
+    this.text = value;
+  }
+}

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -3,6 +3,7 @@ package com.enf.repository;
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.UserEntity;
+import com.enf.model.type.ThanksType;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -65,8 +66,8 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
 
   @Modifying
   @Transactional
-  @Query("UPDATE letter_status ls SET ls.isThanksToMentor = true WHERE ls.letterStatusSeq =:letterStatusSeq")
-  void thankToMentor(Long letterStatusSeq);
+  @Query("UPDATE letter_status ls SET ls.thanksType = :thanksType WHERE ls.letterStatusSeq =:letterStatusSeq")
+  void thankToMentor(Long letterStatusSeq, ThanksType thanksType);
 
   LetterStatusEntity getLetterStatusByMentorLetterLetterSeq(Long letterSeq);
   

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -31,7 +31,7 @@ public interface LetterService {
 
   ResultResponse throwLetter(HttpServletRequest request, Long letterStatusSeq);
 
-  ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String tyoe);
+  ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String type);
 
   ResultResponse getThrowLetterCategory(HttpServletRequest request);
 

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -31,7 +31,7 @@ public interface LetterService {
 
   ResultResponse throwLetter(HttpServletRequest request, Long letterStatusSeq);
 
-  ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq);
+  ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String tyoe);
 
   ResultResponse getThrowLetterCategory(HttpServletRequest request);
 

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -5,7 +5,6 @@ import com.enf.component.facade.UserFacade;
 import com.enf.entity.LetterEntity;
 import com.enf.entity.LetterStatusEntity;
 import com.enf.entity.UserEntity;
-import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.notification.NotificationDTO;
@@ -16,7 +15,6 @@ import com.enf.model.dto.response.letter.LetterDetailsDTO;
 import com.enf.model.dto.response.letter.LetterResponseDto;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
-import com.enf.model.type.FailedResultType;
 import com.enf.model.type.LetterListType;
 import com.enf.model.type.SuccessResultType;
 import com.enf.model.type.TokenType;
@@ -152,8 +150,8 @@ public class LetterServiceImpl implements LetterService {
    * 고마움 전달 로직을 수행하는 메서드
    */
   @Override
-  public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq) {
-    LetterStatusEntity letterStatus = letterFacade.thanksToMentor(letterSeq);
+  public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String tyoe) {
+    LetterStatusEntity letterStatus = letterFacade.thanksToMentor(letterSeq, tyoe);
 
     redisTemplate.convertAndSend("notifications", NotificationDTO.thanksToMentor(letterStatus));
     return ResultResponse.of(SuccessResultType.SUCCESS_THANKS_TO_MENTOR);

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -150,8 +150,8 @@ public class LetterServiceImpl implements LetterService {
    * 고마움 전달 로직을 수행하는 메서드
    */
   @Override
-  public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String tyoe) {
-    LetterStatusEntity letterStatus = letterFacade.thanksToMentor(letterSeq, tyoe);
+  public ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String type) {
+    LetterStatusEntity letterStatus = letterFacade.thanksToMentor(letterSeq, type);
 
     redisTemplate.convertAndSend("notifications", NotificationDTO.thanksToMentor(letterStatus));
     return ResultResponse.of(SuccessResultType.SUCCESS_THANKS_TO_MENTOR);


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
#### LetterFacade.java
   - thanksToMentor 메서드의 파라미터 추가 (String type → ThanksType thanksType)
   - ThanksType.valueOf(type)를 이용하여 ThanksType으로 변환
   - letterStatusRepository.thankToMentor(letterStatus.getLetterStatusSeq(), thanksType) 호출 시 thanksType을 추가

#### LetterController.java
   - thanksToMentor 엔드포인트에서 type를 String 파라미터로 추가
   - letterService.thanksToMentor(request, letterSeq, type)로 변경하여 전달

#### LetterStatusEntity.java
   - isThanksToMentor 필드를 제거 (boolean → ThanksType으로 변경)
   - thanksType 필드 추가 (@Enumerated(EnumType.STRING) 적용)

#### LetterDetailsDTO.java
   - thanksToMentor 필드 추가 (String)
   - letterStatus.getThanksType().getText()을 활용하여 LetterDetailsDTO 생성 시 thanksToMentor 값 설정

#### ReceiveLetterDTO.java
   - thanksToMentor 필드 추가 (boolean)
   - letterStatus.getThanksType() != null 값을 활용하여 true/false 설정

#### ThanksType.java
   - 새로운 Enum 클래스 추가 (MOVED, HELPFUL, NOT_ALONE)
   - text 필드를 가지고 있으며, 이를 통해 한글 메시지를 제공

#### LetterStatusRepository.java
   - thankToMentor 메서드 수정 (isThanksToMentor → thanksType 변경)
   - UPDATE 쿼리를 thanksType 필드에 맞게 수정

#### LetterService.java
   - thanksToMentor 메서드 수정 (type 파라미터 추가)

#### LetterServiceImpl.java
   - letterFacade.thanksToMentor(letterSeq, type)로 변경하여 ThanksType을 처리
   - redisTemplate.convertAndSend("notifications", NotificationDTO.thanksToMentor(letterStatus)); 유지

## 스크린샷

## 주의사항

Closes #65 
