### PR TITLE
feat : 편지 기록 조회 API 구현

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/LetterFacade.java
@@ -11,6 +11,7 @@ import com.enf.exception.GlobalException;
 import com.enf.model.dto.request.letter.ReplyLetterDTO;
 import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.letter.LetterDetailsDTO;
+import com.enf.model.dto.response.letter.LetterHistoryDTO;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
 import com.enf.model.type.FailedResultType;
@@ -213,5 +214,26 @@ public class LetterFacade {
 
   public void updateNotificationIsRead(LetterStatusEntity letterStatus) {
    notificationRepository.updateNotificationIsRead(letterStatus.getLetterStatusSeq());
+  }
+
+  public LetterHistoryDTO getLetterHistory(UserEntity user) {
+    boolean isMentee = user.getRole().getRoleName().equals("MENTEE");
+    List<LetterStatusEntity> letterStatus = isMentee
+        ? letterStatusRepository.findAllByMentee(user)
+        : letterStatusRepository.findAllByMentor(user);
+
+    int sendletter = 0;
+    int replyletter = 0;
+
+    for (LetterStatusEntity status : letterStatus) {
+      if (isMentee) {
+        if (status.getMenteeLetter() != null) sendletter++;
+        if (status.getMentorLetter() != null) replyletter++;
+      } else {
+        if (status.getMentorLetter() != null) sendletter++;
+        if (status.getMenteeLetter() != null) replyletter++;
+      }
+    }
+    return new LetterHistoryDTO(sendletter, replyletter);
   }
 }

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -159,6 +159,13 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/letter/history")
+  public ResponseEntity<ResultResponse> getLetterHistory(HttpServletRequest request) {
+
+    ResultResponse response = letterService.getLetterHistory(request);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
   @GetMapping("/throws/category")
   public ResponseEntity<ResultResponse> getThrowLetterCategory(HttpServletRequest request) {
 

--- a/EnF/src/main/java/com/enf/model/dto/response/letter/LetterHistoryDTO.java
+++ b/EnF/src/main/java/com/enf/model/dto/response/letter/LetterHistoryDTO.java
@@ -1,0 +1,16 @@
+package com.enf.model.dto.response.letter;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LetterHistoryDTO {
+
+  private int sendLetter;
+
+  private int replyLetter;
+
+}

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -31,6 +31,7 @@ public enum SuccessResultType {
   SUCCESS_GET_ALL_BIRDY(HttpStatus.OK, "모든 새 유형 조회 성공"),
   SUCCESS_GET_BIRDY_TIPS(HttpStatus.OK, "버디 팁 조회 성공"),
   SUCCESS_GET_NOTIFICATION(HttpStatus.OK, "알림 조회 성공"),
+  SUCCESS_GET_LETTER_HISTORY(HttpStatus.OK, "편지 기록 조회 성공!"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -106,4 +106,8 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
       "FROM letter_status lst " +
       "WHERE lst.mentor.userSeq = :userSeq AND lst.isMentorRead = false")
   Boolean existsMentorRead(@Param("userSeq") Long userSeq);
+
+  List<LetterStatusEntity> findAllByMentee(UserEntity user);
+
+  List<LetterStatusEntity> findAllByMentor(UserEntity user);
 }

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -34,4 +34,5 @@ public interface LetterService {
 
   ResultResponse getThrowLetterCategory(HttpServletRequest request);
 
+  ResultResponse getLetterHistory(HttpServletRequest request);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -12,6 +12,7 @@ import com.enf.model.dto.response.PageResponse;
 import com.enf.model.dto.response.ResultResponse;
 import com.enf.model.dto.response.letter.LetterDetailResponseDto;
 import com.enf.model.dto.response.letter.LetterDetailsDTO;
+import com.enf.model.dto.response.letter.LetterHistoryDTO;
 import com.enf.model.dto.response.letter.LetterResponseDto;
 import com.enf.model.dto.response.letter.ReceiveLetterDTO;
 import com.enf.model.dto.response.letter.ThrowLetterCategoryDTO;
@@ -171,6 +172,14 @@ public class LetterServiceImpl implements LetterService {
     ThrowLetterCategoryDTO throwLetterCategory = ThrowLetterCategoryDTO.of(letterFacade.getThrowLetterCategory());
 
     return new ResultResponse(SuccessResultType.SUCCESS_GET_THROW_LETTER_CATEGORY, throwLetterCategory);
+  }
+
+  @Override
+  public ResultResponse getLetterHistory(HttpServletRequest request) {
+    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
+
+    LetterHistoryDTO letterHistory = letterFacade.getLetterHistory(user);
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_LETTER_HISTORY, letterHistory);
   }
 
 


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
LetterHistoryDTO 추가

사용자의 편지 통계를 반환하는 DTO 생성
sendLetter와 replyLetter 속성 포함
롬복 어노테이션을 활용한 간결한 구현

#### LetterFacade
   - getLetterHistory 메서드 추가
   - 사용자의 역할(멘티/멘토)에 따라 송수신 편지 수를 계산하는 로직 구현
   - 람다와 스트림 API를 활용한 간결한 구현

#### LetterStatusRepository
   - findAllByMentee와 findAllByMentor 메서드 추가
   - 특정 사용자가 멘티/멘토로 참여한 모든 LetterStatus 조회 기능

#### LetterService & LetterServiceImpl
   - getLetterHistory 메서드 시그니처 추가
   - 구현부에서 토큰으로 사용자 조회 후 LetterFacade 통해 편지 이력 조회 기능 구현

#### LetterController
   - /letter/history 엔드포인트 추가 (GET)
   - 사용자의 편지 통계 정보를 조회하는 REST API 구현

#### SuccessResultType
   - SUCCESS_GET_LETTER_HISTORY 응답 타입 추가
   - 적절한 HTTP 상태 코드와 메시지 설정

## 스크린샷

## 주의사항

Closes #75 
