### PR TITLE
[refactor] 카카로 로그인 API 수정 및 사용하지 않은 API 삭제

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/UserFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/UserFacade.java
@@ -10,6 +10,7 @@ import com.enf.entity.RoleEntity;
 import com.enf.entity.UserEntity;
 import com.enf.exception.GlobalException;
 import com.enf.model.dto.auth.AuthTokenDTO;
+import com.enf.model.dto.request.auth.KakaoUserDetailsDTO;
 import com.enf.model.dto.request.letter.SendLetterDTO;
 import com.enf.model.dto.request.user.AdditionalInfoDTO;
 import com.enf.model.dto.request.user.UserCategoryDTO;
@@ -78,8 +79,12 @@ public class UserFacade {
    * @param providerId 외부 OAuth 제공자의 ID
    * @return Optional<UserEntity>
    */
-  public Optional<UserEntity> findByProviderId(String providerId) {
-    return userRepository.findByProviderId(providerId);
+  public UserEntity findByProviderId(KakaoUserDetailsDTO kakaoUserDetails) {
+    return userRepository.findByProviderId(kakaoUserDetails.getProviderId())
+        .orElseGet(() -> {
+          RoleEntity userRole = findRoleByRoleName("UNKNOWN");
+          return saveUser(KakaoUserDetailsDTO.of(kakaoUserDetails, userRole));
+        });
   }
 
   /**

--- a/EnF/src/main/java/com/enf/controller/LetterController.java
+++ b/EnF/src/main/java/com/enf/controller/LetterController.java
@@ -159,13 +159,6 @@ public class LetterController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
-  @GetMapping("/letter/history")
-  public ResponseEntity<ResultResponse> getLetterHistory(HttpServletRequest request) {
-
-    ResultResponse response = letterService.getLetterHistory(request);
-    return new ResponseEntity<>(response, response.getStatus());
-  }
-
   @GetMapping("/throws/category")
   public ResponseEntity<ResultResponse> getThrowLetterCategory(HttpServletRequest request) {
 

--- a/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/SuccessResultType.java
@@ -31,7 +31,6 @@ public enum SuccessResultType {
   SUCCESS_GET_ALL_BIRDY(HttpStatus.OK, "모든 새 유형 조회 성공"),
   SUCCESS_GET_BIRDY_TIPS(HttpStatus.OK, "버디 팁 조회 성공"),
   SUCCESS_GET_NOTIFICATION(HttpStatus.OK, "알림 조회 성공"),
-  SUCCESS_GET_LETTER_HISTORY(HttpStatus.OK, "편지 기록 조회 성공!"),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/service/LetterService.java
+++ b/EnF/src/main/java/com/enf/service/LetterService.java
@@ -33,6 +33,4 @@ public interface LetterService {
   ResultResponse thanksToMentor(HttpServletRequest request, Long letterSeq, String type);
 
   ResultResponse getThrowLetterCategory(HttpServletRequest request);
-
-  ResultResponse getLetterHistory(HttpServletRequest request);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -177,14 +177,6 @@ public class LetterServiceImpl implements LetterService {
     return new ResultResponse(SuccessResultType.SUCCESS_GET_THROW_LETTER_CATEGORY, throwLetterCategory);
   }
 
-  @Override
-  public ResultResponse getLetterHistory(HttpServletRequest request) {
-    UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
-
-    LetterHistoryDTO letterHistory = letterFacade.getLetterHistory(user);
-    return new ResultResponse(SuccessResultType.SUCCESS_GET_LETTER_HISTORY, letterHistory);
-  }
-
 
   @Transactional(readOnly = true)
   public ResponseEntity<Map<String, Object>> getAllMenteeLetters(HttpServletRequest request, int page, int size) {


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
#### UserFacade.java
   - findByProviderId 메소드 변경 및 구현 로직 수정
   - 파라미터가 String에서 KakaoUserDetailsDTO로 변경
   - 사용자가 존재하지 않을 경우 새 사용자 생성 로직을 포함하도록 수정



#### AuthServiceImpl.java
   - oAuthForKakao 메소드 리팩토링
   - 중첩된 Optional 처리 로직을 간소화
   - UserFacade에서 변경된 메소드를 사용하도록 수정
   - 로직 순서 재배치 (회원가입/로그인 및 토큰 생성 순서 변경)

#### LetterController.java
   - /letter/history 엔드포인트 제거

#### LetterService.java
   - getLetterHistory 메소드 정의 제거

#### LetterServiceImpl.java
   - getLetterHistory 메소드 구현 제거

#### SuccessResultType.java
   - SUCCESS_GET_LETTER_HISTORY 응답 타입 제거

## 스크린샷

## 주의사항

Closes #85 
