### PR TITLE
fix : 남은 편지 개수가 0개 일경우 예외처리 로직 추가

### DIFF
--- a/EnF/src/main/java/com/enf/component/facade/UserFacade.java
+++ b/EnF/src/main/java/com/enf/component/facade/UserFacade.java
@@ -318,8 +318,13 @@ public class UserFacade {
    *
    * @param user 사용자 정보
    */
-  public void reduceQuota(UserEntity user) {
-    quotaRepository.reduceQuota(user);
+  public int reduceQuota(UserEntity user) {
+    QuotaEntity quota = quotaRepository.findByUser(user);
+    if (quota.getQuota() == 0) {
+      throw new GlobalException(FailedResultType.QUOTA_IS_EMPTY);
+    }
+    quotaRepository.reduceQuota(quota.getQuotaSeq());
+    return quota.getQuota() - 1;
   }
 
   /**
@@ -329,10 +334,6 @@ public class UserFacade {
    */
   public List<QuotaEntity> getQuotas() {
     return quotaRepository.findAll();
-  }
-
-  public int getQuotaByUserSeq(UserEntity user) {
-    return quotaRepository.findByUser(user).getQuota();
   }
 
 

--- a/EnF/src/main/java/com/enf/model/type/FailedResultType.java
+++ b/EnF/src/main/java/com/enf/model/type/FailedResultType.java
@@ -20,7 +20,8 @@ public enum FailedResultType {
   MENTOR_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "멘토는 접근 권한이 없습니다."),
   ALREADY_REPLIED(HttpStatus.BAD_REQUEST, "이미 답장한 편지는 넘길 수 없습니다."),
   UNLINK_FAILED(HttpStatus.BAD_REQUEST, "회원탈퇴 실패 했습니다"),
-  ALREADY_PENALTY(HttpStatus.BAD_REQUEST, "이미 영구 정지된 회원입니다.")
+  ALREADY_PENALTY(HttpStatus.BAD_REQUEST, "이미 영구 정지된 회원입니다."),
+  QUOTA_IS_EMPTY(HttpStatus.BAD_REQUEST, "남은 편지 개수가 0개 입니다."),
   ;
 
   private final HttpStatus status;

--- a/EnF/src/main/java/com/enf/repository/QuotaRepository.java
+++ b/EnF/src/main/java/com/enf/repository/QuotaRepository.java
@@ -21,8 +21,8 @@ public interface QuotaRepository extends JpaRepository<QuotaEntity, Long> {
   @Transactional
   @Query("UPDATE quota q "
       + "SET q.quota = CASE WHEN q.quota > 0 THEN q.quota - 1 ELSE q.quota END "
-      + "WHERE q.user = :user")
-  void reduceQuota(@Param("user") UserEntity user);
+      + "WHERE q.quotaSeq = :quotaSeq")
+  void reduceQuota(@Param("quotaSeq") Long quotaSeq);
 
   QuotaEntity findByUser(UserEntity user);
 }

--- a/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
+++ b/EnF/src/main/java/com/enf/service/impl/LetterServiceImpl.java
@@ -60,8 +60,7 @@ public class LetterServiceImpl implements LetterService {
     LetterEntity letter = SendLetterDTO.of(sendLetter);
     LetterStatusEntity letterStatus = letterFacade.saveMenteeLetter(letter, mentee, mentor);
 
-    userFacade.reduceQuota(mentee);
-    int quota = userFacade.getQuotaByUserSeq(mentee);
+    int quota = userFacade.reduceQuota(mentee);
     redisTemplate.convertAndSend("notifications", NotificationDTO.sendLetter(letterStatus, mentor));
 
     // 메트릭 추가
@@ -74,11 +73,9 @@ public class LetterServiceImpl implements LetterService {
    */
   @Override
   public ResultResponse replyLetter(HttpServletRequest request, ReplyLetterDTO replyLetter) {
-    UserEntity mentor = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
     LetterStatusEntity letterStatus = letterFacade.saveMentorLetter(replyLetter);
 
-    userFacade.reduceQuota(letterStatus.getMentor());
-    int quota = userFacade.getQuotaByUserSeq(mentor);
+    int quota = userFacade.reduceQuota(letterStatus.getMentor());
     redisTemplate.convertAndSend("notifications", NotificationDTO.replyLetter(letterStatus));
 
     return new ResultResponse(SuccessResultType.SUCCESS_RECEIVE_LETTER, quota);


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
#### UserFacade

   - reduceQuota() 메소드가 void에서 int 리턴 타입으로 변경
   - Quota 체크 로직 추가: quota가 0인 경우 QUOTA_IS_EMPTY 예외 발생
   - 할당량 감소 로직 개선: user 객체 대신 quota.getQuotaSeq()를 사용하도록 변경
   - 남은 할당량(quota - 1)을 반환하도록 수정
   - getQuotaByUserSeq() 메소드 삭제

#### FailedResultType

   - QUOTA_IS_EMPTY 에러 타입 추가: "남은 편지 개수가 0개 입니다."

#### QuotaRepository

   - reduceQuota() 메소드의 파라미터 변경: UserEntity user → Long quotaSeq
   - 쿼리 조건절 변경: "WHERE q.user = :user" → "WHERE q.quotaSeq = :quotaSeq"

#### LetterServiceImpl

   - sendLetter()와 replyLetter() 메소드에서 할당량 감소 로직 간소화
   - userFacade.reduceQuota() 호출 결과를 직접 quota 변수에 할당하도록 변경
   - userFacade.getQuotaByUserSeq() 호출 제거
   - replyLetter() 메소드에서 불필요한 mentor 객체 생성 코드 제거

## 스크린샷

## 주의사항

Closes #89 
