### PR TITLE
[refactor] 편지 읽음 상태 여부 쿼리문 수정

### DIFF
--- a/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
+++ b/EnF/src/main/java/com/enf/entity/LetterStatusEntity.java
@@ -46,7 +46,7 @@ public class LetterStatusEntity {
     private LetterEntity mentorLetter;
 
     @Column(name = "is_mentee_read")
-    private boolean isMenteeRead = false;  // 기본값 설정
+    private boolean isMenteeRead = true;  // 기본값 설정
 
     @Column(name = "is_mentor_read")
     private boolean isMentorRead = false;  // 기본값 설정
@@ -69,10 +69,6 @@ public class LetterStatusEntity {
           .mentee(mentee)
           .mentor(mentor)
           .menteeLetter(menteeLetter)
-          .isMenteeRead(false)
-          .isMentorRead(false)
-          .isMenteeSaved(false)
-          .isMentorSaved(false)
           .thanksType(null)
           .createAt(LocalDateTime.now())
           .build();

--- a/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
+++ b/EnF/src/main/java/com/enf/repository/LetterStatusRepository.java
@@ -22,7 +22,10 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
   @Modifying
   @Transactional
   @Query("UPDATE letter_status ls "
-      + "SET ls.mentorLetter = :mentorLetter, ls.createAt = CURRENT_TIMESTAMP "
+      + "SET ls.mentorLetter = :mentorLetter, "
+      + "ls.createAt = CURRENT_TIMESTAMP, "
+      + "ls.isMentorRead = true, "
+      + "ls.isMenteeRead = false "
       + "WHERE ls.letterStatusSeq = :letterStatusSeq")
   void saveMentorLetter(
       @Param("letterStatusSeq") Long letterStatusSeq,
@@ -66,7 +69,10 @@ public interface LetterStatusRepository extends JpaRepository<LetterStatusEntity
 
   @Modifying
   @Transactional
-  @Query("UPDATE letter_status ls SET ls.thanksType = :thanksType WHERE ls.letterStatusSeq =:letterStatusSeq")
+  @Query("UPDATE letter_status ls "
+      + "SET ls.thanksType = :thanksType, "
+      + "ls.isMentorRead = false "
+      + "WHERE ls.letterStatusSeq =:letterStatusSeq")
   void thankToMentor(Long letterStatusSeq, ThanksType thanksType);
 
   LetterStatusEntity getLetterStatusByMentorLetterLetterSeq(Long letterSeq);


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

#### LetterStatusEntity 변경사항
- `isMenteeRead` 기본값을 `false`에서 `true`로 변경
- `of()` 메서드에서 불필요한 읽음 상태 초기화 코드 제거 (기본값 사용)
  - `isMenteeRead(false)` 제거
  - `isMentorRead(false)` 제거
  - `isMenteeSaved(false)` 제거
  - `isMentorSaved(false)` 제거

#### LetterStatusRepository 변경사항
- `saveMentorLetter()` 메서드 업데이트
  - 멘토가 답장을 작성할 때 멘토의 읽음 상태(`isMentorRead`)를 `true`로 설정
  - 멘티의 읽음 상태(`isMenteeRead`)를 `false`로 재설정
  
- `thankToMentor()` 메서드 업데이트
  - 멘티가 감사 메시지를 보낼 때 멘토의 읽음 상태(`isMentorRead`)를 `false`로 설정하여 새 알림 발생

## 스크린샷

## 주의사항

Closes #92 
