### PR TITLE
Dear 126 문의하기 api 확인

### DIFF
--- a/EnF/module-api/src/main/java/com/enf/api/component/KakaoAuthHandler.java
+++ b/EnF/module-api/src/main/java/com/enf/api/component/KakaoAuthHandler.java
@@ -40,6 +40,7 @@ public class KakaoAuthHandler {
   private String adminKey;
 
   private String adminRedirectUri = "https://api.dearbirdy.xyz/api/v1/admin/callback";;
+//  private String adminRedirectUri ="http://localhost:8080/api/v1/admin/callback";
 
   //토큰 조회를 위한 메서드
   public String getAccessToken(HttpServletRequest request, String code) {

--- a/EnF/module-api/src/main/java/com/enf/api/controller/AdminController.java
+++ b/EnF/module-api/src/main/java/com/enf/api/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.enf.api.controller;
 
+import com.enf.domain.model.dto.request.inquiry.InquiryDTO;
+import com.enf.domain.model.dto.response.ResultResponse;
 import com.enf.domain.model.dto.response.letter.LetterDetailResponseDto;
 import com.enf.api.service.AdminService;
 import com.enf.api.service.AuthService;
@@ -72,20 +74,10 @@ public class AdminController {
      * @param page 페이지 번호 (기본값: 0)
      * @param size 페이지 크기 (기본값: 10)
      * @param status 문의 상태 (선택적: PENDING, ANSWERED)
-     * @return
-     * inquiries{
-     *     id, : 문의 아이디
-     *     title, : 문의 제목
-     *     author, : 작성자
-     *     createdAt, : 문의 날짜
-     *     status : 문의 상태
-     * },
-     * currentPage : 현재 페이지
-     * totalItems : 문의 전체 갯수
-     * totalPages : 전체 페이지 수
+     * @return 문의 목록 정보
      */
     @GetMapping("/inquiries")
-    public ResponseEntity<Map<String, Object>> getInquiries(
+    public ResponseEntity<ResultResponse> getInquiries(
             HttpServletRequest request,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -93,8 +85,9 @@ public class AdminController {
 
         // 페이지 정보 구성 (최신순 정렬)
         Pageable pageable = PageRequest.of(page, size, Sort.by("createAt").descending());
-        // 응답 변환 및 반환
-        return inquiryService.getInquiries(request, pageable, status);
+        // 응답 반환
+        ResultResponse response =  inquiryService.getInquiries(request, pageable, status);
+        return new ResponseEntity<>(response, response.getStatus());
     }
 
     /**
@@ -104,32 +97,33 @@ public class AdminController {
      * @return 문의 상세 정보
      */
     @GetMapping("/inquiries/{id}")
-    public ResponseEntity<Map<String, Object>> getInquiryDetail(
+    public ResponseEntity<ResultResponse> getInquiryDetail(
             HttpServletRequest request,
             @PathVariable Long id) {
-        return inquiryService.getInquiryDetail(request, id);
+        ResultResponse response =  inquiryService.getInquiryDetail(request, id);
+        return new ResponseEntity<>(response, response.getStatus());
     }
 
     /**
      * 문의 답변 등록 API
      *
      * @param id 문의 시퀀스
-     * @param responseRequest 답변 내용
+     * @param inquiryDTO 답변 내용
      * @param request 요청 객체 (헤더에서 관리자 정보 추출)
      * @return 등록 결과
      */
     @PostMapping("/inquiries/{id}/responses")
-    public ResponseEntity<Map<String, Object>> createResponse(
+    public ResponseEntity<ResultResponse> createResponse(
             @PathVariable Long id,
-            @RequestBody Map<String, String> responseRequest,
+            @RequestBody InquiryDTO inquiryDTO,
             HttpServletRequest request) {
 
-        // 답변 내용 추출
-        String content = responseRequest.get("content");
+        String content = inquiryDTO.getContent();
         if (content == null || content.trim().isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
-        return inquiryService.createResponse(request, id, content);
+        ResultResponse response =  inquiryService.createResponse(request, id, content);
+        return new ResponseEntity<>(response, response.getStatus());
     }
 
     //-----------편지관련 api-----------

--- a/EnF/module-api/src/main/java/com/enf/api/controller/AuthController.java
+++ b/EnF/module-api/src/main/java/com/enf/api/controller/AuthController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
-//Test URL : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=962b24a09f42380d01cc640c02a3b71d&redirect_uri=http://localhost:8080/api/v1/auth/callback
+//Local Test URL : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3d37d53cb427928f2a93ea16263d08de&redirect_uri=http://localhost:8080/api/v1/auth/callback
+//DevServer Test URL : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3d37d53cb427928f2a93ea16263d08de&redirect_uri=https://api.dearbirdy.xyz/api/v1/auth/callback
+//DevServer Test URL : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3d37d53cb427928f2a93ea16263d08de&redirect_uri=http://localhost:3000/callback
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/EnF/module-api/src/main/java/com/enf/api/controller/InquiryController.java
+++ b/EnF/module-api/src/main/java/com/enf/api/controller/InquiryController.java
@@ -1,6 +1,8 @@
 package com.enf.api.controller;
 
 import com.enf.api.service.InquiryService;
+import com.enf.domain.model.dto.request.inquiry.InquiryDTO;
+import com.enf.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -21,20 +23,20 @@ public class InquiryController {
      * 문의 등록 API
      *
      * @param request 요청 객체 (헤더에서 사용자 정보 추출)
-     * @param inquiryRequest 문의 내용
+     * @param inquiryDTO 문의 내용을 포함한 DTO
      * @return 등록 결과
      */
     @PostMapping
-    public ResponseEntity<Map<String, Object>> createInquiry(
+    public ResponseEntity<ResultResponse> createInquiry(
             HttpServletRequest request,
-            @RequestBody Map<String, String> inquiryRequest) {
+            @RequestBody InquiryDTO inquiryDTO) {
 
-        // 문의 내용 추출
-        String content = inquiryRequest.get("content");
-        if (content == null || content.trim().isEmpty()) {
+        // 문의 내용 검증
+        if (inquiryDTO.getContent() == null || inquiryDTO.getContent().trim().isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
 
-        return inquiryService.createInquiry(request, content);
+        ResultResponse response = inquiryService.createInquiry(request, inquiryDTO);
+        return new ResponseEntity<>(response, response.getStatus());
     }
 }

--- a/EnF/module-api/src/main/java/com/enf/api/service/InquiryService.java
+++ b/EnF/module-api/src/main/java/com/enf/api/service/InquiryService.java
@@ -2,6 +2,8 @@ package com.enf.api.service;
 
 import com.enf.domain.entity.InquiryEntity;
 import com.enf.domain.entity.InquiryResponseEntity;
+import com.enf.domain.model.dto.request.inquiry.InquiryDTO;
+import com.enf.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import org.springframework.data.domain.Page;
@@ -13,59 +15,38 @@ public interface InquiryService {
     /**
      * 문의 등록
      *
-     * @param content 문의 내용
+     * @param request 요청 객체 (헤더에서 사용자 정보 추출)
+     * @param inquiryDTO 문의 내용을 포함한 DTO
      * @return 등록된 문의 정보
      */
-    ResponseEntity<Map<String, Object>> createInquiry(HttpServletRequest request, String content);
+    ResultResponse createInquiry(HttpServletRequest request, InquiryDTO inquiryDTO);
 
     /**
      * 문의 목록 조회 (페이징)
      *
+     * @param request 요청 객체 (헤더에서 사용자 정보 추출)
      * @param pageable 페이지 정보
      * @param status 문의 상태 (선택적)
      * @return 문의 목록
      */
-    ResponseEntity<Map<String, Object>> getInquiries(HttpServletRequest request, Pageable pageable, String status);
+    ResultResponse getInquiries(HttpServletRequest request, Pageable pageable, String status);
 
     /**
      * 문의 상세 조회
      *
+     * @param request 요청 객체 (헤더에서 사용자 정보 추출)
      * @param inquirySeq 문의 시퀀스
      * @return 문의 상세 정보
      */
-    ResponseEntity<Map<String, Object>> getInquiryDetail(HttpServletRequest request, Long inquirySeq);
+    ResultResponse getInquiryDetail(HttpServletRequest request, Long inquirySeq);
 
     /**
      * 문의 답변 등록
      *
-     * @param adminSeq 관리자 시퀀스
+     * @param request 요청 객체 (헤더에서 사용자 정보 추출)
+     * @param inquiryId 문의 ID
      * @param content 답변 내용
      * @return 등록된 답변 정보
      */
-    ResponseEntity<Map<String, Object>> createResponse(HttpServletRequest request, Long adminSeq, String content);
-
-    /**
-     * 문의 목록을 응답 형식으로 변환
-     *
-     * @param inquiries 문의 목록
-     * @param pageable 페이지 정보
-     * @return 응답 데이터
-     */
-    Map<String, Object> convertToResponse(Page<InquiryEntity> inquiries, Pageable pageable);
-
-    /**
-     * 문의 상세 정보를 응답 형식으로 변환
-     *
-     * @param inquiry 문의 상세 정보
-     * @return 응답 데이터
-     */
-    Map<String, Object> convertToDetailResponse(InquiryEntity inquiry);
-
-    /**
-     * 답변 정보를 응답 형식으로 변환
-     *
-     * @param response 답변 정보
-     * @return 응답 데이터
-     */
-    Map<String, Object> convertToResponseDetail(InquiryResponseEntity response);
+    ResultResponse createResponse(HttpServletRequest request, Long inquiryId, String content);
 }

--- a/EnF/module-api/src/main/java/com/enf/api/service/impl/InquiryServiceImpl.java
+++ b/EnF/module-api/src/main/java/com/enf/api/service/impl/InquiryServiceImpl.java
@@ -4,6 +4,14 @@ import com.enf.api.component.facade.UserFacade;
 import com.enf.domain.entity.InquiryEntity;
 import com.enf.domain.entity.InquiryResponseEntity;
 import com.enf.domain.entity.UserEntity;
+import com.enf.domain.model.dto.request.inquiry.InquiryDTO;
+import com.enf.domain.model.dto.request.inquiry.InquiryDetailDTO;
+import com.enf.domain.model.dto.request.inquiry.InquiryPageResponseDTO;
+import com.enf.domain.model.dto.response.ResultResponse;
+import com.enf.domain.model.dto.response.inquiry.CreateInquiryResponseDTO;
+import com.enf.domain.model.dto.response.inquiry.InquiryResponseResultDTO;
+import com.enf.domain.model.type.FailedResultType;
+import com.enf.domain.model.type.SuccessResultType;
 import com.enf.domain.model.type.TokenType;
 import com.enf.domain.repository.InquiryRepository;
 import com.enf.domain.repository.InquiryResponseRepository;
@@ -18,6 +26,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,13 +42,12 @@ public class InquiryServiceImpl implements InquiryService {
 
     @Override
     @Transactional
-    public ResponseEntity<Map<String, Object>> createInquiry(HttpServletRequest request, String content) {
-
+    public ResultResponse createInquiry(HttpServletRequest request, InquiryDTO inquiryDTO) {
         UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
 
         InquiryEntity inquiry = InquiryEntity.builder()
                 .user(user)
-                .content(content)
+                .content(inquiryDTO.getContent())
                 .status(InquiryEntity.InquiryStatus.PENDING)
                 .createAt(LocalDateTime.now())
                 .build();
@@ -48,21 +56,17 @@ public class InquiryServiceImpl implements InquiryService {
         inquiry.setTitleFromContent();
         InquiryEntity inquiryResult = inquiryRepository.save(inquiry);
 
-        // 응답 구성
-        Map<String, Object> response = new HashMap<>();
-        response.put("message", "문의가 성공적으로 등록되었습니다.");
-        response.put("inquiryId", inquiryResult.getInquirySeq());
-
-        return ResponseEntity.ok(response);
+        // CreateInquiryResponseDTO 사용하여 응답 생성
+        CreateInquiryResponseDTO responseDTO = CreateInquiryResponseDTO.of(inquiryResult.getInquirySeq());
+        return new ResultResponse(SuccessResultType.SUCCESS_CREATE_INQUIRY, responseDTO);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public ResponseEntity<Map<String, Object>> getInquiries(HttpServletRequest request, Pageable pageable, String status) {
-
+    public ResultResponse getInquiries(HttpServletRequest request, Pageable pageable, String status) {
         UserEntity adminAccount = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
         if (!adminAccount.getRole().getRoleName().equals("ADMIN")) {
-            return ResponseEntity.badRequest().build();
+            return new ResultResponse(FailedResultType.ADMIN_PERMISSION_DENIED, null);
         }
 
         Page<InquiryEntity> inquiries;
@@ -75,119 +79,77 @@ public class InquiryServiceImpl implements InquiryService {
                 // 잘못된 상태값이 전달된 경우 모든 문의 반환
                 inquiries = inquiryRepository.findAll(pageable);
             }
+        } else {
+            inquiries = inquiryRepository.findAll(pageable);
         }
-        inquiries = inquiryRepository.findAll(pageable);
 
-        return ResponseEntity.ok(convertToResponse(inquiries, pageable));
+        // InquiryPageResponseDTO 사용하여 응답 생성
+        InquiryPageResponseDTO responseDTO = InquiryPageResponseDTO.from(inquiries);
+        return new ResultResponse(SuccessResultType.SUCCESS_GET_INQUIRY, responseDTO);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public ResponseEntity<Map<String, Object>> getInquiryDetail(HttpServletRequest request,Long inquirySeq) {
-
+    public ResultResponse getInquiryDetail(HttpServletRequest request, Long inquirySeq) {
         UserEntity adminAccount = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
         if (!adminAccount.getRole().getRoleName().equals("ADMIN")) {
-            return ResponseEntity.badRequest().build();
+            return new ResultResponse(FailedResultType.ADMIN_PERMISSION_DENIED, null);
         }
 
-        InquiryEntity inquiry = inquiryRepository.findById(inquirySeq)
-                .orElseThrow(() -> new EntityNotFoundException("문의를 찾을 수 없습니다: " + inquirySeq));
-        return ResponseEntity.ok(convertToDetailResponse(inquiry));
+        try {
+            InquiryEntity inquiry = inquiryRepository.findById(inquirySeq)
+                    .orElseThrow(() -> new EntityNotFoundException("문의를 찾을 수 없습니다: " + inquirySeq));
+
+            // InquiryDetailDTO 사용하여 응답 생성
+            InquiryDetailDTO detailDTO = InquiryDetailDTO.from(inquiry);
+            return new ResultResponse(SuccessResultType.SUCCESS_GET_INQUIRY, detailDTO);
+        } catch (EntityNotFoundException e) {
+            return new ResultResponse(FailedResultType.INQUIRY_NOT_FOUND, null);
+        }
     }
 
     @Override
     @Transactional
-    public ResponseEntity<Map<String, Object>> createResponse(HttpServletRequest request, Long inquiryId, String content) {
-
+    public ResultResponse createResponse(HttpServletRequest request, Long inquiryId, String content) {
         UserEntity adminAccount = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
         if (!adminAccount.getRole().getRoleName().equals("ADMIN")) {
-            return ResponseEntity.badRequest().build();
+            return new ResultResponse(FailedResultType.ADMIN_PERMISSION_DENIED, null);
         }
+
         Long inquirySeq = inquiryId;
-        Long adminSeq = adminAccount.getRole().getRoleSeq();
+        Long adminSeq = adminAccount.getUserSeq();
 
-        InquiryEntity inquiry = inquiryRepository.findById(inquirySeq)
-                .orElseThrow(() -> new EntityNotFoundException("문의를 찾을 수 없습니다: " + inquirySeq));
+        try {
+            InquiryEntity inquiry = inquiryRepository.findById(inquirySeq)
+                    .orElseThrow(() -> new EntityNotFoundException("문의를 찾을 수 없습니다: " + inquirySeq));
 
-        UserEntity admin = userRepository.findById(adminSeq)
-                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다: " + adminSeq));
+            UserEntity admin = userRepository.findById(adminSeq)
+                    .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다: " + adminSeq));
 
-        // 이미 답변이 있는지 확인
-        if (inquiry.getStatus() == InquiryEntity.InquiryStatus.ANSWERED) {
-            throw new IllegalStateException("이미 답변이 등록된 문의입니다.");
+            // 이미 답변이 있는지 확인
+            if (inquiry.getStatus() == InquiryEntity.InquiryStatus.ANSWERED) {
+                return new ResultResponse(FailedResultType.INQUIRY_ALREADY_ANSWERED, null);
+            }
+
+            InquiryResponseEntity responseInquiry = InquiryResponseEntity.builder()
+                    .inquiry(inquiry)
+                    .content(content)
+                    .admin(admin)
+                    .createAt(LocalDateTime.now())
+                    .build();
+
+            // 문의 상태 변경
+            inquiry.markAsAnswered();
+            inquiryRepository.save(inquiry);
+
+            InquiryResponseEntity responseEntity = responseRepository.save(responseInquiry);
+
+            // InquiryResponseResultDTO 사용하여 응답 생성
+            InquiryResponseResultDTO resultDTO = InquiryResponseResultDTO.from(responseEntity);
+
+            return new ResultResponse(SuccessResultType.SUCCESS_CREATE_INQUIRY_RESPONSE, resultDTO);
+        } catch (EntityNotFoundException e) {
+            return new ResultResponse(FailedResultType.INQUIRY_NOT_FOUND, null);
         }
-
-        InquiryResponseEntity responseInquiry = InquiryResponseEntity.builder()
-                .inquiry(inquiry)
-                .content(content)
-                .admin(admin)
-                .createAt(LocalDateTime.now())
-                .build();
-
-        // 문의 상태 변경
-        inquiry.markAsAnswered();
-        inquiryRepository.save(inquiry);
-
-        InquiryResponseEntity response = responseRepository.save(responseInquiry);
-        // 응답 구성
-        Map<String, Object> result = new HashMap<>();
-        result.put("message", "답변이 성공적으로 등록되었습니다.");
-        result.put("response", convertToResponseDetail(response));
-
-        return ResponseEntity.ok(result);
-    }
-
-    @Override
-    public Map<String, Object> convertToResponse(Page<InquiryEntity> inquiries, Pageable pageable) {
-        Map<String, Object> response = new HashMap<>();
-
-        response.put("inquiries", inquiries.getContent().stream()
-                .map(inquiry -> {
-                    Map<String, Object> inquiryMap = new HashMap<>();
-                    inquiryMap.put("id", inquiry.getInquirySeq());
-                    inquiryMap.put("title", inquiry.getTitle());
-                    inquiryMap.put("author", inquiry.getUser().getNickname());
-                    inquiryMap.put("createdAt", inquiry.getCreateAt().toString());
-                    inquiryMap.put("status", inquiry.getStatus().name());
-                    return inquiryMap;
-                })
-                .collect(Collectors.toList()));
-
-        response.put("currentPage", pageable.getPageNumber());
-        response.put("totalItems", inquiries.getTotalElements());
-        response.put("totalPages", inquiries.getTotalPages());
-
-        return response;
-    }
-
-    @Override
-    public Map<String, Object> convertToDetailResponse(InquiryEntity inquiry) {
-        Map<String, Object> response = new HashMap<>();
-
-        response.put("id", inquiry.getInquirySeq());
-        response.put("title", inquiry.getTitle());
-        response.put("content", inquiry.getContent());
-        response.put("author", inquiry.getUser().getNickname());
-        response.put("createdAt", inquiry.getCreateAt().toString());
-        response.put("status", inquiry.getStatus().name());
-
-        // 답변이 있는 경우 응답에 포함
-        if (inquiry.getStatus() == InquiryEntity.InquiryStatus.ANSWERED && inquiry.getResponse() != null) {
-            response.put("response", convertToResponseDetail(inquiry.getResponse()));
-        }
-
-        return response;
-    }
-
-    @Override
-    public Map<String, Object> convertToResponseDetail(InquiryResponseEntity response) {
-        Map<String, Object> responseMap = new HashMap<>();
-
-        responseMap.put("id", response.getResponseSeq());
-        responseMap.put("content", response.getContent());
-        responseMap.put("respondent", response.getAdmin().getNickname());
-        responseMap.put("createdAt", response.getCreateAt().toString());
-
-        return responseMap;
     }
 }

--- a/EnF/module-api/src/main/resources/templates/admin/dashboard.html
+++ b/EnF/module-api/src/main/resources/templates/admin/dashboard.html
@@ -1409,8 +1409,8 @@
             })
             .then(data => {
               if (data) {
-                inquiriesData = data;
-                renderInquiriesList(data);
+                inquiriesData = data.data;
+                renderInquiriesList(data.data);
               }
             })
             .catch(error => {
@@ -1565,7 +1565,7 @@
             })
             .then(data => {
               if (data) {
-                renderInquiryDetail(data);
+                renderInquiryDetail(data.data);
               }
             })
             .catch(error => {

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryDTO.java
@@ -1,0 +1,17 @@
+package com.enf.domain.model.dto.request.inquiry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class InquiryDTO {
+
+    @JsonProperty("content")
+    private String content;
+
+    @JsonCreator
+    public InquiryDTO(String content) {
+        this.content = content;
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryDetailDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryDetailDTO.java
@@ -1,0 +1,44 @@
+package com.enf.domain.model.dto.request.inquiry;
+
+import com.enf.domain.entity.InquiryEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryDetailDTO {
+    private Long id;
+    private String title;
+    private String content;
+    private String author;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    private String status;
+    private InquiryResponseDTO response;
+
+    public static InquiryDetailDTO from(InquiryEntity inquiry) {
+        InquiryDetailDTOBuilder builder = InquiryDetailDTO.builder()
+                .id(inquiry.getInquirySeq())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .author(inquiry.getUser().getNickname())
+                .createdAt(inquiry.getCreateAt())
+                .status(inquiry.getStatus().name());
+
+        // 답변이 있는 경우 응답에 포함
+        if (inquiry.getStatus() == InquiryEntity.InquiryStatus.ANSWERED && inquiry.getResponse() != null) {
+            builder.response(InquiryResponseDTO.from(inquiry.getResponse()));
+        }
+
+        return builder.build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryListDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryListDTO.java
@@ -1,0 +1,35 @@
+package com.enf.domain.model.dto.request.inquiry;
+
+import com.enf.domain.entity.InquiryEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryListDTO {
+    private Long id;
+    private String title;
+    private String author;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    private String status;
+
+    public static InquiryListDTO from(InquiryEntity inquiry) {
+        return InquiryListDTO.builder()
+                .id(inquiry.getInquirySeq())
+                .title(inquiry.getTitle())
+                .author(inquiry.getUser().getNickname())
+                .createdAt(inquiry.getCreateAt())
+                .status(inquiry.getStatus().name())
+                .build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryPageResponseDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryPageResponseDTO.java
@@ -1,0 +1,35 @@
+package com.enf.domain.model.dto.request.inquiry;
+
+import com.enf.domain.entity.InquiryEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryPageResponseDTO {
+    private List<InquiryListDTO> inquiries;
+    private int currentPage;
+    private long totalItems;
+    private int totalPages;
+
+    public static InquiryPageResponseDTO from(Page<InquiryEntity> inquiriesPage) {
+        List<InquiryListDTO> inquiriesList = inquiriesPage.getContent().stream()
+                .map(InquiryListDTO::from)
+                .collect(Collectors.toList());
+
+        return InquiryPageResponseDTO.builder()
+                .inquiries(inquiriesList)
+                .currentPage(inquiriesPage.getNumber())
+                .totalItems(inquiriesPage.getTotalElements())
+                .totalPages(inquiriesPage.getTotalPages())
+                .build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryResponseDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/inquiry/InquiryResponseDTO.java
@@ -1,0 +1,32 @@
+package com.enf.domain.model.dto.request.inquiry;
+
+import com.enf.domain.entity.InquiryResponseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryResponseDTO {
+    private Long id;
+    private String content;
+    private String respondent;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    public static InquiryResponseDTO from(InquiryResponseEntity response) {
+        return InquiryResponseDTO.builder()
+                .id(response.getResponseSeq())
+                .content(response.getContent())
+                .respondent(response.getAdmin().getNickname())
+                .createdAt(response.getCreateAt())
+                .build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/response/inquiry/CreateInquiryResponseDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/response/inquiry/CreateInquiryResponseDTO.java
@@ -1,0 +1,22 @@
+package com.enf.domain.model.dto.response.inquiry;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateInquiryResponseDTO {
+    private String message;
+    private Long inquiryId;
+
+    public static CreateInquiryResponseDTO of(Long inquiryId) {
+        return CreateInquiryResponseDTO.builder()
+                .message("문의가 성공적으로 등록되었습니다.")
+                .inquiryId(inquiryId)
+                .build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/response/inquiry/InquiryResponseResultDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/response/inquiry/InquiryResponseResultDTO.java
@@ -1,0 +1,24 @@
+package com.enf.domain.model.dto.response.inquiry;
+
+import com.enf.domain.entity.InquiryResponseEntity;
+import com.enf.domain.model.dto.request.inquiry.InquiryResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryResponseResultDTO {
+    private String message;
+    private InquiryResponseDTO response;
+
+    public static InquiryResponseResultDTO from(InquiryResponseEntity responseEntity) {
+        return InquiryResponseResultDTO.builder()
+                .message("답변이 성공적으로 등록되었습니다.")
+                .response(InquiryResponseDTO.from(responseEntity))
+                .build();
+    }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/type/FailedResultType.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/type/FailedResultType.java
@@ -23,6 +23,9 @@ public enum FailedResultType {
   ALREADY_PENALTY(HttpStatus.BAD_REQUEST, "이미 영구 정지된 회원입니다."),
   QUOTA_IS_EMPTY(HttpStatus.BAD_REQUEST, "남은 편지 개수가 0개 입니다."),
   BIRD_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 새 타입 입니다."),
+  ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+  INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 문의입니다."),
+  INQUIRY_ALREADY_ANSWERED(HttpStatus.BAD_REQUEST, "이미 답변이 등록된 문의입니다."),
   ;
 
   private final HttpStatus status;

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/type/SuccessResultType.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/type/SuccessResultType.java
@@ -32,6 +32,9 @@ public enum SuccessResultType {
   SUCCESS_GET_BIRDY_TIPS(HttpStatus.OK, "버디 팁 조회 성공"),
   SUCCESS_GET_NOTIFICATION(HttpStatus.OK, "알림 조회 성공"),
   SUCCESS_UPDATE_BIRD_TYPE(HttpStatus.OK, "버디 타입 수정 성공"),
+  SUCCESS_CREATE_INQUIRY(HttpStatus.CREATED, "문의가 성공적으로 등록되었습니다."),
+  SUCCESS_GET_INQUIRY(HttpStatus.OK, "문의 조회 성공"),
+  SUCCESS_CREATE_INQUIRY_RESPONSE(HttpStatus.CREATED, "문의 답변이 성공적으로 등록되었습니다.");
   ;
 
   private final HttpStatus status;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용

1. 문의하기 api 파라미터 받아오는 방식 변경
    - 기존 Map<String, Object> → ContentRequest로 변경
2. ContentRequest를 따로 만들어서 content를 담고 받아오는 DTO를 생성
3. 성공 / 실패시  반환 방법 변경
    - 기존 코드의 응답 타입(ResponseType)은 ResponseEntity<Map<String, Object>>를 이용해서 반환
    - Type 변경 : ResponseEntity<Map<String, Object>>   →   ResultResponse
    - ResultResponse를 통해서 반환하며, 기존과 동일한 형태로 리스폰을 하도록 유지 하였다.

[문의하기 api 확인 & 테스트]
- localhost 환경에서 테스트를 진행함.
- DB에 데이터가 적재되는것을 확인하였음.

[문의하기 관리자 api 확인하기]
- 문의하기를 하였을경우 관리자 페이지에서 해당 문의 목록이 확인 되는지 테스트 완료함
- InquiryServiceImpl 반환값 리팩토링
    - 문의 목록 조회 api
    - 문의 상세 조회 api
    - 문의 답변 등록 api

