### PR TITLE
Dear 138 회원탈퇴 api 수정

### DIFF
--- a/EnF/module-api/src/main/java/com/enf/api/component/facade/UserFacade.java
+++ b/EnF/module-api/src/main/java/com/enf/api/component/facade/UserFacade.java
@@ -8,8 +8,10 @@ import com.enf.domain.entity.LetterStatusEntity;
 import com.enf.domain.entity.RoleEntity;
 import com.enf.domain.entity.UserEntity;
 import com.enf.api.exception.GlobalException;
+import com.enf.domain.entity.WithdrawalEntity;
 import com.enf.domain.model.dto.auth.AuthTokenDTO;
 import com.enf.domain.model.dto.request.auth.KakaoUserDetailsDTO;
+import com.enf.domain.model.dto.request.auth.WithdrawalDTO;
 import com.enf.domain.model.dto.request.letter.SendLetterDTO;
 import com.enf.domain.model.dto.request.user.AdditionalInfoDTO;
 import com.enf.domain.model.dto.request.user.UserCategoryDTO;
@@ -17,11 +19,13 @@ import com.enf.domain.model.dto.response.letter.LetterHistoryDTO;
 import com.enf.domain.model.dto.response.user.UserProfileDTO;
 import com.enf.domain.model.type.FailedResultType;
 import com.enf.domain.model.type.TokenType;
+import com.enf.domain.model.type.WithdrawalType;
 import com.enf.domain.repository.BirdRepository;
 import com.enf.domain.repository.CategoryRepository;
 import com.enf.domain.repository.LetterStatusRepository;
 import com.enf.domain.repository.RoleRepository;
 import com.enf.domain.repository.UserRepository;
+import com.enf.domain.repository.WithdrawalRepository;
 import com.enf.domain.repository.querydsl.UserQueryRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -43,6 +47,7 @@ public class UserFacade {
   private final TokenProvider tokenProvider;
   private final UserQueryRepository userQueryRepository;
   private final LetterStatusRepository letterStatusRepository;
+  private final WithdrawalRepository withdrawalRepository;
 
   // ============================= User 관련 메서드 =============================
 
@@ -177,10 +182,17 @@ public class UserFacade {
   /**
    * 회원 탈퇴 보류 처리
    *
-   * @param user UserEntity
+   * @param user          UserEntity
+   * @param withdrawalDTO
    */
-  public void pendingWithdrawal(UserEntity user) {
+  public void pendingWithdrawal(UserEntity user, WithdrawalDTO withdrawalDTO) {
+    WithdrawalEntity withdrawal = WithdrawalEntity.builder()
+        .withdrawalUser(user.getNickname())
+        .withdrawalType(WithdrawalType.valueOf(withdrawalDTO.getWithdrawalType()))
+        .build();
+
     userRepository.pendingWithdrawal(user.getUserSeq());
+    withdrawalRepository.save(withdrawal);
   }
 
 
@@ -212,6 +224,7 @@ public class UserFacade {
    */
   public void cancelWithdrawal(UserEntity user) {
     userRepository.cancelWithdrawal(user.getUserSeq());
+    withdrawalRepository.deleteByWithdrawalUser(user.getNickname());
   }
 
 

--- a/EnF/module-api/src/main/java/com/enf/api/controller/AuthController.java
+++ b/EnF/module-api/src/main/java/com/enf/api/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.enf.api.controller;
 
+import com.enf.domain.model.dto.request.auth.WithdrawalDTO;
 import com.enf.domain.model.dto.response.ResultResponse;
 import com.enf.api.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,10 +71,11 @@ public class AuthController {
     return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 
-  @GetMapping("/withdrawal")
-  public ResponseEntity<ResultResponse> withdrawal(HttpServletRequest request) {
+  @PostMapping("/withdrawal")
+  public ResponseEntity<ResultResponse> withdrawal(HttpServletRequest request,
+      WithdrawalDTO withdrawalDTO) {
 
-    ResultResponse resultResponse = authService.withdrawal(request);
+    ResultResponse resultResponse = authService.withdrawal(request, withdrawalDTO);
     return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 }

--- a/EnF/module-api/src/main/java/com/enf/api/service/AuthService.java
+++ b/EnF/module-api/src/main/java/com/enf/api/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.enf.api.service;
 
 
+import com.enf.domain.model.dto.request.auth.WithdrawalDTO;
 import com.enf.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,5 +16,5 @@ public interface AuthService {
 
   ResultResponse reissueToken(HttpServletRequest request, HttpServletResponse response);
 
-  ResultResponse withdrawal(HttpServletRequest request);
+  ResultResponse withdrawal(HttpServletRequest request, WithdrawalDTO withdrawalDTO);
 }

--- a/EnF/module-api/src/main/java/com/enf/api/service/impl/AuthServiceImpl.java
+++ b/EnF/module-api/src/main/java/com/enf/api/service/impl/AuthServiceImpl.java
@@ -5,8 +5,10 @@ import com.enf.api.component.facade.UserFacade;
 import com.enf.domain.entity.RoleEntity;
 import com.enf.domain.entity.UserEntity;
 import com.enf.api.exception.GlobalException;
+import com.enf.domain.entity.WithdrawalEntity;
 import com.enf.domain.model.dto.auth.UserDetailsDTO;
 import com.enf.domain.model.dto.request.auth.KakaoUserDetailsDTO;
+import com.enf.domain.model.dto.request.auth.WithdrawalDTO;
 import com.enf.domain.model.dto.response.ResultResponse;
 import com.enf.domain.model.type.FailedResultType;
 import com.enf.domain.model.type.SuccessResultType;
@@ -114,9 +116,9 @@ public class AuthServiceImpl implements AuthService {
    * @return 회원탈퇴 결과 응답 객체
    */
   @Override
-  public ResultResponse withdrawal(HttpServletRequest request) {
+  public ResultResponse withdrawal(HttpServletRequest request, WithdrawalDTO withdrawalDTO) {
     UserEntity user = userFacade.getUserByToken(request.getHeader(TokenType.ACCESS.getValue()));
-    userFacade.pendingWithdrawal(user);
+    userFacade.pendingWithdrawal(user, withdrawalDTO);
 
     return ResultResponse.of(SuccessResultType.SUCCESS_KAKAO_WITHDRAWAL);
   }

--- a/EnF/module-domain/src/main/java/com/enf/domain/entity/WithdrawalEntity.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/entity/WithdrawalEntity.java
@@ -1,0 +1,31 @@
+package com.enf.domain.entity;
+
+import com.enf.domain.model.type.WithdrawalType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "withdrawal")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class WithdrawalEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long withdrawalSeq;
+
+  private String withdrawalUser;
+
+  @Enumerated(EnumType.STRING)
+  private WithdrawalType withdrawalType;
+
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/auth/WithdrawalDTO.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/dto/request/auth/WithdrawalDTO.java
@@ -1,0 +1,18 @@
+package com.enf.domain.model.dto.request.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class WithdrawalDTO {
+
+  @JsonProperty("withdrawalType")
+
+  private String withdrawalType;
+
+  @JsonCreator
+  public WithdrawalDTO(String withdrawalType) {
+    this.withdrawalType = withdrawalType;
+  }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/model/type/WithdrawalType.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/model/type/WithdrawalType.java
@@ -1,0 +1,18 @@
+package com.enf.domain.model.type;
+
+import lombok.Getter;
+
+@Getter
+public enum WithdrawalType {
+
+  NO_DESIRED_ACTIVITY("원하는 활동이 없어요"),
+  NOT_HELPFUL_FOR_PROBLEMS("고민을 해결하는 데 도움이 안돼요"),
+  INCONVENIENT_SERVICE("서비스를 이용하기가 불편해요"),
+  OTHER("기타");
+
+  private final String value;
+
+  WithdrawalType(String value) {
+    this.value = value;
+  }
+}

--- a/EnF/module-domain/src/main/java/com/enf/domain/repository/WithdrawalRepository.java
+++ b/EnF/module-domain/src/main/java/com/enf/domain/repository/WithdrawalRepository.java
@@ -1,0 +1,12 @@
+package com.enf.domain.repository;
+
+import com.enf.domain.entity.WithdrawalEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WithdrawalRepository extends JpaRepository<WithdrawalEntity, Long> {
+
+  void deleteByWithdrawalUser(String user);
+
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원 탈퇴 사유 추가 로직 구현

#### UserFacade

- WithdrawalEntity, WithdrawalDTO, WithdrawalType 관련 import 추가
- withdrawalRepository 멤버 변수 추가
- pendingWithdrawal 메서드에 WithdrawalDTO 파라미터 추가 및 WithdrawalEntity 생성 후 저장 로직 구현
- cancelWithdrawal 메서드에 탈퇴 사유 삭제 로직 추가

#### AuthController

- WithdrawalDTO import 추가
- 회원 탈퇴 API 엔드포인트 메서드를 GET에서 POST로 변경
- 회원 탈퇴 메서드에 WithdrawalDTO 파라미터 추가

#### AuthService

- WithdrawalDTO import 추가
- withdrawal 메서드 시그니처에 WithdrawalDTO 파라미터 추가
- AuthServiceImpl
- WithdrawalEntity, WithdrawalDTO import 추가
- withdrawal 메서드 구현에 WithdrawalDTO 파라미터 추가 및 userFacade.pendingWithdrawal 호출 시 전달

#### WithdrawalEntity

- 회원 탈퇴 정보를 저장하는 새로운 엔티티 클래스 생성
- withdrawalSeq, withdrawalUser, withdrawalType 필드 추가

#### WithdrawalDTO

- 회원 탈퇴 사유를 전달받기 위한 DTO 클래스 생성
- withdrawalType 필드 추가

#### WithdrawalType

- 회원 탈퇴 사유 타입을 정의하는 Enum 클래스 생성
- NO_DESIRED_ACTIVITY, NOT_HELPFUL_FOR_PROBLEMS, INCONVENIENT_SERVICE, OTHER 타입 정의

#### WithdrawalRepository

- WithdrawalEntity를 관리하는 Repository 인터페이스 생성
- deleteByWithdrawalUser 메서드 추가

## 스크린샷

## 주의사항

Closes #{이슈 번호}
